### PR TITLE
the blt:telemetry line is repeated on line 39 -- don't think line 32 is needed

### DIFF
--- a/blt/src/Blt/Plugin/Commands/AmpCommands.php
+++ b/blt/src/Blt/Plugin/Commands/AmpCommands.php
@@ -29,7 +29,6 @@ class AmpCommands extends BltTasks {
     $this->_exec("mkdir -p web/sites/default/settings");
     $this->_exec("cp blt/lando.local.settings.php web/sites/default/settings/local.settings.php");
     $this->_exec("lando composer install --ignore-platform-reqs -n");
-    $this->_exec("blt blt:telemetry:disable --no-interaction");
     $hash = \Drupal\Component\Utility\Crypt::randomBytesBase64(55);
     $this->_exec("echo 'PANTHEON_ENVIRONMENT=local
 DRUPAL_HASH_SALT=$hash


### PR DESCRIPTION
plus it was failing without being preceeded with `lando`