### PR TITLE
codespaces: test using internal GITHUB_TOKEN

### DIFF
--- a/.devcontainer/codespaces.sh
+++ b/.devcontainer/codespaces.sh
@@ -12,4 +12,4 @@ mkdir -p ~/.lando/cache
 composer install --ignore-platform-reqs -n
 blt blt:telemetry:disable --no-interaction
 lando blt blt:telemetry:disable --no-interaction
-blt amp:landosetup $AMP_GH_TOKEN_REPO $AMP_USER
+blt amp:landosetup $GITHUB_TOKEN $AMP_USER


### PR DESCRIPTION
With the permissions added from Tina's snippet I switched from AMP_GH_TOKEN_REPO to GITHUB_TOKEN (the included token), and everything appears to work as expected. @a-pasquale you can remove that secret after you merge this in.