### PR TITLE
Md 1227

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -17060,13 +17060,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/amp_dev.git",
-                "reference": "896702567a870aac5897488c1b81117c011d992a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/necyberteam/amp_dev/zipball/896702567a870aac5897488c1b81117c011d992a",
-                "reference": "896702567a870aac5897488c1b81117c011d992a",
-                "shasum": ""
+                "reference": "374e83ccd900b36f28923c7c9a15e3b85f4fe58b"
             },
             "default-branch": true,
             "type": "drupal-custom-module",
@@ -17078,11 +17072,7 @@
             "keywords": [
                 "Drupal"
             ],
-            "support": {
-                "source": "https://github.com/necyberteam/amp_dev/tree/main",
-                "issues": "https://github.com/necyberteam/amp_dev/issues"
-            },
-            "time": "2022-08-28T16:34:50+00:00"
+            "time": "2023-02-02T18:29:07+00:00"
         },
         {
             "name": "composer/ca-bundle",

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -15,3 +15,8 @@ workflows:
       - type: webphp
         description: Import configuration
         script: private/scripts/drush_deploy/drush_deploy.php
+  clone_database:
+    after:
+      - type: webphp
+        description: Turn off non-prod site functions
+        script: private/scripts/no_prod.php

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -20,3 +20,8 @@ workflows:
       - type: webphp
         description: Turn off non-prod site functions
         script: private/scripts/no_prod.php
+  create_cloud_development_environment:
+    after:
+      - type: webphp
+        description: Turn off non-prod site functions
+        script: private/scripts/no_prod.php

--- a/web/private/scripts/drush_deploy/drush_deploy.php
+++ b/web/private/scripts/drush_deploy/drush_deploy.php
@@ -6,4 +6,3 @@ echo "Import of configuration complete.\n";
 echo "Rebuilding cache.\n";
 passthru('drush cr');
 echo "Rebuilding cache complete.\n";
-

--- a/web/private/scripts/no_prod.php
+++ b/web/private/scripts/no_prod.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @file
+ * Turn off non-prod site functions..
+ */
+
+echo "Disable constant contact cron run.\n";
+passthru('drush php:eval "\\Drupal::state()->set(\'access_affinitygroup.alloc_cron_disable\', TRUE);"');
+echo "Disable constant contact cron run complete.\n";


### PR DESCRIPTION
This connects to https://cyberteamportal.atlassian.net/browse/D8-1227. As this is set as a drupal active state, I'm setting it via the amp_dev module so it trickles down to local instances of the site. And I'm attempting to set it via quicksilver for other non-prod instances of the site. This needs more testing as it wouldn't trigger in the md version of my site. It may need to go to the main branch to actually get set, I'm not sure. This should run a drush command that will set this checkbox whenever the db is cloned or else whenever a new multidev site is created.