### PR TITLE
Change url for unused account assistance webform

### DIFF
--- a/web/sites/default/config/default/webform.webform.account_assistance.yml
+++ b/web/sites/default/config/default/webform.webform.account_assistance.yml
@@ -49,7 +49,7 @@ settings:
   ajax_effect: ''
   ajax_speed: null
   page: true
-  page_submit_path: ''
+  page_submit_path: /form/old_account_assistance
   page_confirm_path: ''
   page_theme_name: ''
   form_title: source_entity_webform
@@ -127,6 +127,8 @@ settings:
   wizard_toggle: true
   wizard_toggle_show_label: ''
   wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
   preview: 0
   preview_label: ''
   preview_title: ''


### PR DESCRIPTION
We are redirecting tickets to JSM so move this webform to a difference url so that we can create a new direct from /form/account-assistance to point to the new JSM form.

Ready for review.