### PR TITLE
Md d8 1164 - from 'resource' to 'CI link'

### DIFF
--- a/web/sites/default/config/default/block.block.accessresourcespageintro.yml
+++ b/web/sites/default/config/default/block.block.accessresourcespageintro.yml
@@ -35,4 +35,4 @@ visibility:
   request_path:
     id: request_path
     negate: false
-    pages: /resources
+    pages: /ci-links

--- a/web/sites/default/config/default/block.block.addresourcebutton.yml
+++ b/web/sites/default/config/default/block.block.addresourcebutton.yml
@@ -28,4 +28,4 @@ visibility:
     id: request_path
     negate: false
     context_mapping: {  }
-    pages: "/resources\r\n/resources_card"
+    pages: "/ci-links\r\n/ci-links-card"

--- a/web/sites/default/config/default/block.block.resourcescard.yml
+++ b/web/sites/default/config/default/block.block.resourcescard.yml
@@ -28,4 +28,4 @@ visibility:
     id: request_path
     negate: false
     context_mapping: {  }
-    pages: /resources_card
+    pages: /ci-links-card

--- a/web/sites/default/config/default/block.block.resourceslist.yml
+++ b/web/sites/default/config/default/block.block.resourceslist.yml
@@ -28,4 +28,4 @@ visibility:
     id: request_path
     negate: false
     context_mapping: {  }
-    pages: /resources
+    pages: /ci-links

--- a/web/sites/default/config/default/field.field.node.affinity_group.field_resources_entity_reference.yml
+++ b/web/sites/default/config/default/field.field.node.affinity_group.field_resources_entity_reference.yml
@@ -9,12 +9,12 @@ dependencies:
     - label_help
 third_party_settings:
   label_help:
-    label_help_description: 'Start typing and look for the Resource you want to attach. If you need to upload a new resource, do that first on the <a href="/resources/">Resources</a> page.'
+    label_help_description: 'Start typing and look for the CI Link you want to attach. If you need to upload a new CI Link, do that first on the <a href="/ci-links/">CI Links</a> page.'
 id: node.affinity_group.field_resources_entity_reference
 field_name: field_resources_entity_reference
 entity_type: node
 bundle: affinity_group
-label: 'Display Resources on your Affinity Group'
+label: 'Display CI Links on your Affinity Group'
 description: ''
 required: false
 translatable: false

--- a/web/sites/default/config/default/views.view.resource.yml
+++ b/web/sites/default/config/default/views.view.resource.yml
@@ -24,7 +24,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: Resource
+      title: 'CI Link'
       fields:
         link_flag:
           id: link_flag

--- a/web/sites/default/config/default/views.view.resource.yml
+++ b/web/sites/default/config/default/views.view.resource.yml
@@ -652,7 +652,7 @@ display:
           changefreq: ''
           arguments: {  }
           max_links: 100
-      path: resource/%
+      path: ci-link/%
     cache_metadata:
       max-age: -1
       contexts:

--- a/web/sites/default/config/default/views.view.resources.yml
+++ b/web/sites/default/config/default/views.view.resources.yml
@@ -28,7 +28,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: Resources
+      title: 'CI Links'
       fields:
         sid:
           id: sid
@@ -1438,7 +1438,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="alert alert-warning">There are no resources associated with this topic. Please check back often as more resources are added regularly, or view <a href="/resources">All Resources</a>.</div>'
+            value: '<div class="alert alert-warning">There are no CI Links associated with this topic. Please check back often as more CI Links are added regularly, or view <a href="/ci_links">CI Links</a>.</div>'
             format: full_html
           tokenize: false
       sorts: {  }
@@ -2032,6 +2032,7 @@ display:
           webform_element_format: value
           webform_multiple_value: true
           webform_multiple_delta: 0
+          webform_check_access: 1
         webform_submission_value_1:
           id: webform_submission_value_1
           table: webform_submission_field_resource_description
@@ -2064,7 +2065,7 @@ display:
             ellipsis: true
             more_link: true
             more_link_text: ''
-            more_link_path: 'resource/{{ sid }}'
+            more_link_path: 'ci-link/{{ sid }}'
             strip_tags: false
             trim: true
             preserve_tags: ''
@@ -2084,6 +2085,7 @@ display:
           webform_element_format: value
           webform_multiple_value: true
           webform_multiple_delta: 0
+          webform_check_access: 1
         webform_submission_value:
           id: webform_submission_value
           table: webform_submission_field_resource_category
@@ -2315,7 +2317,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "{{ webform_submission_value_4 }}\r\n{{ webform_submission_value_7 }}\r\n{{ webform_submission_value_8 }}\r\n{% if webform_submission_value_6 %} <a href=\"/resource/{{sid}}\">more</a> {% endif %}"
+            text: "{{ webform_submission_value_4 }}\r\n{{ webform_submission_value_7 }}\r\n{{ webform_submission_value_8 }}\r\n{% if webform_submission_value_6 %} <a href=\"/ci-link/{{sid}}\">more</a> {% endif %}"
             make_link: false
             path: ''
             absolute: false
@@ -2422,7 +2424,7 @@ display:
           exclude: true
           alter:
             alter_text: true
-            text: '<a href="/resource/{{ sid_1 }}">view</a>'
+            text: '<a href="/ci-link/{{ sid_1 }}">view</a>'
             make_link: false
             path: ''
             absolute: false
@@ -2605,7 +2607,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="alert alert-warning mx-3">There are no resources at this time. Please check back often as resources are added regularly.</div>'
+            value: '<div class="alert alert-warning mx-3">There are no CI Links at this time. Please check back often as CI Links are added regularly.</div>'
             format: full_no_editor
           tokenize: false
       sorts:
@@ -2653,14 +2655,44 @@ display:
           id: webform_id
           table: webform_submission
           field: webform_id
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: webform_submission
           entity_field: webform_id
           plugin_id: bundle
+          operator: in
           value:
             resource: resource
+          group: 1
+          exposed: false
           expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
             operator_limit_selection: false
             operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         webform_submission_value:
           id: webform_submission_value
           table: webform_submission_field_resource_approved
@@ -2935,10 +2967,10 @@ display:
               prefix: ''
               separator: ', '
               suffix: ''
-      path: resources
+      path: ci-links
       menu:
         type: normal
-        title: Resources
+        title: 'CI Links'
         description: ''
         weight: -41
         expanded: true
@@ -4042,11 +4074,11 @@ display:
           entity_type: webform_submission
           entity_field: sid
           plugin_id: field
-          label: 'View Resource'
+          label: 'View CI Link'
           exclude: true
           alter:
             alter_text: true
-            text: '<a href="/resource/{{ sid_1 }}">view</a>'
+            text: '<a href="/ci-link/{{ sid_1 }}">view</a>'
             make_link: false
             path: ''
             absolute: false
@@ -4230,7 +4262,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"card mx-auto align-self-center text-center\" style=\"height: 500px;\">\r\n<div class=\"card-body\">\r\n<h5 class=\"mt-3\"><a href=\"/resource/{{ sid }}\">{{ webform_submission_value_5 }}</a></h5>\r\n<hr>\r\n<p>{{ webform_submission_value_1 }}</p>\r\n<p>{{ webform_submission_value }}</p>\r\n<p>{{ webform_submission_value_4 }}   {{ webform_submission_value_7 }}   {{ webform_submission_value_8 }}</p>\r\n<p>{{ webform_submission_value_3 }}</p>\r\n</div>\r\n</div>"
+            text: "<div class=\"card mx-auto align-self-center text-center\" style=\"height: 500px;\">\r\n<div class=\"card-body\">\r\n<h5 class=\"mt-3\"><a href=\"/ci-link/{{ sid }}\">{{ webform_submission_value_5 }}</a></h5>\r\n<hr>\r\n<p>{{ webform_submission_value_1 }}</p>\r\n<p>{{ webform_submission_value }}</p>\r\n<p>{{ webform_submission_value_4 }}   {{ webform_submission_value_7 }}   {{ webform_submission_value_8 }}</p>\r\n<p>{{ webform_submission_value_3 }}</p>\r\n</div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -4270,6 +4302,7 @@ display:
           webform_element_format: value
           webform_multiple_value: true
           webform_multiple_delta: 0
+          webform_check_access: 1
       empty:
         area:
           id: area
@@ -4623,7 +4656,7 @@ display:
               prefix: ''
               separator: ', '
               suffix: ''
-      path: resources_card
+      path: ci-links-card
       menu:
         type: none
         title: Resources

--- a/web/sites/default/config/default/views.view.resources.yml
+++ b/web/sites/default/config/default/views.view.resources.yml
@@ -531,7 +531,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="alert alert-warning mx-3">There are no resources at this time. Please check back often as resources are added regularly.</div>'
+            value: '<div class="alert alert-warning mx-3">There are no CI Links at this time. Please check back often as CI Links are added regularly.</div>'
             format: full_no_editor
           tokenize: false
       sorts:
@@ -790,7 +790,7 @@ display:
       group_by: false
       use_more: false
       use_more_always: false
-      use_more_text: 'View all Resources with this tag'
+      use_more_text: 'View all CI Links with this tag'
       link_display: page_2
       link_url: /
       header:
@@ -804,7 +804,7 @@ display:
           plugin_id: text
           empty: false
           content:
-            value: '{% if not link_flag %}Log in to vote on resources.{% endif %}'
+            value: '{% if not link_flag %}Log in to vote on CI Links.{% endif %}'
             format: basic_html
           tokenize: true
       footer: {  }
@@ -820,7 +820,7 @@ display:
       tags: {  }
   block_1:
     id: block_1
-    display_title: 'Resources by Tag'
+    display_title: 'CI Links by Tag'
     display_plugin: block
     position: 2
     display_options:
@@ -1271,11 +1271,11 @@ display:
           entity_type: webform_submission
           entity_field: sid
           plugin_id: field
-          label: 'View Resource'
+          label: 'View CI Link'
           exclude: true
           alter:
             alter_text: true
-            text: '<a href="/resource/{{ sid_1 }}">view</a>'
+            text: '<a href="/ci-link/{{ sid_1 }}">view</a>'
             make_link: false
             path: ''
             absolute: false
@@ -1591,7 +1591,7 @@ display:
       tags: {  }
   block_3:
     id: block_3
-    display_title: 'Resources by Tag'
+    display_title: 'CI Links by Tag'
     display_plugin: block
     position: 2
     display_options:
@@ -1722,7 +1722,7 @@ display:
       display_description: 'All Resources'
       use_more: true
       use_more_always: false
-      use_more_text: 'All Resources with this tag'
+      use_more_text: 'All CI Links with this tag'
       header:
         area:
           id: area

--- a/web/sites/default/config/default/views.view.resources.yml
+++ b/web/sites/default/config/default/views.view.resources.yml
@@ -108,7 +108,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: '<a href="/resource/{{ sid }}">{{ webform_submission_value_5 }}</a>'
+            text: '<a href="/ci-link/{{ sid }}">{{ webform_submission_value_5 }}</a>'
             make_link: false
             path: ''
             absolute: false
@@ -148,6 +148,7 @@ display:
           webform_element_format: value
           webform_multiple_value: true
           webform_multiple_delta: 0
+          webform_check_access: 1
         webform_submission_value:
           id: webform_submission_value
           table: webform_submission_field_resource_category
@@ -318,7 +319,7 @@ display:
           exclude: true
           alter:
             alter_text: true
-            text: '<a href="/resource/{{ sid_1 }}">view</a>'
+            text: '<a href="/ci-link/{{ sid_1 }}">view</a>'
             make_link: false
             path: ''
             absolute: false
@@ -840,7 +841,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="alert alert-warning">There are no Resources associated with this topic. View <a href="/resources">All Resources</a>.</div>'
+            value: '<div class="alert alert-warning">There are no CI Links associated with this topic. View <a href="/ci-links">All CI Links</a>.</div>'
             format: full_html
           tokenize: false
       arguments:
@@ -1063,7 +1064,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: '<a href="/resource/{{ sid }}">{{ webform_submission_value_5 }}</a>'
+            text: '<a href="/ci-link/{{ sid }}">{{ webform_submission_value_5 }}</a>'
             make_link: false
             path: ''
             absolute: false
@@ -1103,6 +1104,7 @@ display:
           webform_element_format: value
           webform_multiple_value: true
           webform_multiple_delta: 0
+          webform_check_access: 1
         webform_submission_value:
           id: webform_submission_value
           table: webform_submission_field_resource_category
@@ -1438,7 +1440,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="alert alert-warning">There are no CI Links associated with this topic. Please check back often as more CI Links are added regularly, or view <a href="/ci_links">CI Links</a>.</div>'
+            value: '<div class="alert alert-warning">There are no CI Links associated with this topic. Please check back often as more CI Links are added regularly, or view <a href="/ci-links">CI Links</a>.</div>'
             format: full_html
           tokenize: false
       sorts: {  }
@@ -1609,7 +1611,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="alert alert-warning">There are no Resources associated with this topic. View <a href="/resources">All Resources</a>.</div>'
+            value: '<div class="alert alert-warning">There are no CI Links associated with this topic. View <a href="/ci-links">All CI Links</a>.</div>'
             format: full_html
           tokenize: false
       arguments:
@@ -1992,7 +1994,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: '<a href="/resource/{{ sid }}">{{ webform_submission_value_5 }}</a>'
+            text: '<a href="/ci-link/{{ sid }}">{{ webform_submission_value_5 }}</a>'
             make_link: false
             path: ''
             absolute: false
@@ -3075,7 +3077,7 @@ display:
             alter_text: false
             text: ''
             make_link: true
-            path: '/resource/{{ sid }}'
+            path: '/ci-link/{{ sid }}'
             absolute: false
             external: false
             replace_spaces: false
@@ -3341,7 +3343,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="alert alert-warning">There are no resources associated with this topic. Please check back often as more resources are added regularly, or view <a href="/resources">All Resources</a>.</div>'
+            value: '<div class="alert alert-warning">There are no CI Links associated with this topic. Please check back often as more CI Links are added regularly, or view <a href="/ci-links">All CI Links</a>.</div>'
             format: full_html
           tokenize: false
       arguments:
@@ -3456,7 +3458,7 @@ display:
       header: {  }
       display_extenders:
         simple_sitemap_display_extender: {  }
-      path: term/%/resources
+      path: term/%/ci-links
     cache_metadata:
       max-age: -1
       contexts:
@@ -4314,7 +4316,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: '<div class="alert alert-warning mx-3">There are no resources at this time. Please check back often as resources are added regularly.</div>'
+            value: '<div class="alert alert-warning mx-3">There are no CI Links at this time. Please check back often as CI Links are added regularly.</div>'
             format: full_no_editor
           tokenize: false
       sorts:

--- a/web/sites/default/config/default/views.view.resources.yml
+++ b/web/sites/default/config/default/views.view.resources.yml
@@ -952,7 +952,7 @@ display:
       display_description: ''
       use_more: true
       use_more_always: false
-      use_more_text: 'All Resources with this tag'
+      use_more_text: 'All CI Links with this tag'
       header:
         area:
           id: area
@@ -3786,7 +3786,7 @@ display:
             ellipsis: true
             more_link: true
             more_link_text: ''
-            more_link_path: 'resource/{{ sid }}'
+            more_link_path: 'ci-link/{{ sid }}'
             strip_tags: false
             trim: true
             preserve_tags: ''

--- a/web/sites/default/config/default/webform.webform.resource.yml
+++ b/web/sites/default/config/default/webform.webform.resource.yml
@@ -78,7 +78,7 @@ settings:
   ajax_effect: ''
   ajax_speed: null
   page: true
-  page_submit_path: /ci-link
+  page_submit_path: /form/ci-link
   page_confirm_path: ''
   page_theme_name: ''
   form_title: source_entity_webform
@@ -107,7 +107,7 @@ settings:
   form_reset: false
   form_access_denied: login
   form_access_denied_title: ''
-  form_access_denied_message: 'You must be logged in to add a resource. Please <a href="/user/login">Log in</a> or <a href="/user/register">Join the Team</a>.'
+  form_access_denied_message: 'You must be logged in to add a CI Link. Please <a href="/user/login">Log in</a> or <a href="/user/register">Join the Team</a>.'
   form_access_denied_attributes: {  }
   form_file_limit: ''
   form_attributes: {  }

--- a/web/sites/default/config/default/webform.webform.resource.yml
+++ b/web/sites/default/config/default/webform.webform.resource.yml
@@ -79,7 +79,7 @@ settings:
   ajax_speed: null
   page: true
   page_submit_path: /form/ci-link
-  page_confirm_path: ''
+  page_confirm_path: /form/ci-link/confirmation
   page_theme_name: ''
   form_title: source_entity_webform
   form_submit_once: false
@@ -174,7 +174,7 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: url
-  confirmation_url: 'webform/resource/submissions/[webform_submission:sid]'
+  confirmation_url: 'webform/ci-link/submissions/[webform_submission:sid]'
   confirmation_title: ''
   confirmation_message: ''
   confirmation_attributes: {  }

--- a/web/sites/default/config/default/webform.webform.resource.yml
+++ b/web/sites/default/config/default/webform.webform.resource.yml
@@ -9,7 +9,7 @@ uid: 138
 template: false
 archive: false
 id: resource
-title: Resource
+title: 'CI Link'
 description: ''
 category: ''
 elements: |-
@@ -59,7 +59,7 @@ elements: |-
     '#title': Description
   link_to_resource:
     '#type': webform_link
-    '#title': 'Link to Resource'
+    '#title': 'Link to CI Link'
     '#multiple': true
   terms:
     '#type': textfield
@@ -78,7 +78,7 @@ settings:
   ajax_effect: ''
   ajax_speed: null
   page: true
-  page_submit_path: ''
+  page_submit_path: /ci-link
   page_confirm_path: ''
   page_theme_name: ''
   form_title: source_entity_webform
@@ -156,6 +156,8 @@ settings:
   wizard_toggle: true
   wizard_toggle_show_label: ''
   wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
   preview: 0
   preview_label: ''
   preview_title: ''


### PR DESCRIPTION
Change from 'resource' to 'CI link'. The word "resource" is widely used and can be confused with other kinds of resources. We are changing these community contributed items to "CI Links" or "Cyberinfrastructure Links". This change has the configuration changes needed for this. Other places will also need content changes through drupal including menu items and page content. See the associated spreadsheet in the Jira ticket.

Test:
https://md-d8-1164-accessmatch.pantheonsite.io/

Check webform submission, /resources page, individual resource page.
Test content changes.

Jira:
https://cyberteamportal.atlassian.net/jira/software/c/projects/D8/boards/6?modal=detail&selectedIssue=D8-1164
