### PR TITLE
Use new steering committee roles to filter people page #md-1250

### DIFF
--- a/web/sites/default/config/default/nodeaccess.settings.yml
+++ b/web/sites/default/config/default/nodeaccess.settings.yml
@@ -755,18 +755,18 @@ role_alias:
     weight: 0
     allow: 0
   sc:
-    alias: SC
-    name: SC
+    alias: 'steering committee'
+    name: 'steering committee'
     weight: 0
     allow: 0
   lt:
-    alias: LT
-    name: LT
+    alias: 'leadership team'
+    name: 'leadership team'
     weight: 0
     allow: 0
   ra:
-    alias: RA
-    name: RA
+    alias: 'regional admin'
+    name: 'regional admin'
     weight: 0
     allow: 0
   careers_sc:

--- a/web/sites/default/config/default/user.role.lt.yml
+++ b/web/sites/default/config/default/user.role.lt.yml
@@ -19,7 +19,7 @@ dependencies:
     - taxonomy
     - toolbar
 id: lt
-label: LT
+label: 'leadership team'
 weight: 14
 is_admin: null
 permissions:

--- a/web/sites/default/config/default/user.role.ra.yml
+++ b/web/sites/default/config/default/user.role.ra.yml
@@ -19,7 +19,7 @@ dependencies:
     - taxonomy
     - toolbar
 id: ra
-label: RA
+label: 'regional admin'
 weight: 15
 is_admin: null
 permissions:

--- a/web/sites/default/config/default/user.role.sc.yml
+++ b/web/sites/default/config/default/user.role.sc.yml
@@ -19,7 +19,7 @@ dependencies:
     - taxonomy
     - toolbar
 id: sc
-label: SC
+label: 'steering committee'
 weight: 13
 is_admin: null
 permissions:

--- a/web/sites/default/config/default/views.view.people_card_view.yml
+++ b/web/sites/default/config/default/views.view.people_card_view.yml
@@ -8,7 +8,6 @@ dependencies:
     - field.storage.user.field_user_first_name
     - field.storage.user.field_user_last_name
     - field.storage.user.user_picture
-    - image.style.three_by_four
     - taxonomy.vocabulary.region
     - user.role.ci_systems_engineer
     - user.role.domain_champion
@@ -21,6 +20,7 @@ dependencies:
     - user.role.research_computing_facilitator
     - user.role.research_software_engineer
     - user.role.researcher
+    - user.role.sc
     - user.role.steering_committee
     - user.role.student
     - user.role.student_champion
@@ -1049,10 +1049,10 @@ display:
             mentor: mentor
             professional_mentor: professional_mentor
             researcher: researcher
-            steering_committee: steering_committee
             research_computing_facilitator: research_computing_facilitator
             research_software_engineer: research_software_engineer
             ci_systems_engineer: ci_systems_engineer
+            sc: sc
           group: 1
           exposed: true
           expose:
@@ -1087,7 +1087,21 @@ display:
               research_software_engineer: '0'
               ci_systems_engineer: '0'
               mentee: '0'
+              student_champion: '0'
               domain_champion: '0'
+              cssn: '0'
+              affinity_group_leader: '0'
+              match_pm: '0'
+              sc: '0'
+              lt: '0'
+              ra: '0'
+              coco_pm: '0'
+              cnctci_pm: '0'
+              news_pm: '0'
+              kb_pm: '0'
+              careers_sc: '0'
+              ccmnet_pm: '0'
+              match_sc: '0'
             reduce: true
           is_grouped: false
           group_info:

--- a/web/sites/default/config/default/views.view.people_list_view.yml
+++ b/web/sites/default/config/default/views.view.people_list_view.yml
@@ -8,19 +8,21 @@ dependencies:
     - field.storage.user.field_user_first_name
     - field.storage.user.field_user_last_name
     - field.storage.user.user_picture
-    - image.style.3_by_4_forced_dimensions
     - taxonomy.vocabulary.region
     - user.role.ci_systems_engineer
     - user.role.domain_champion
     - user.role.leadership
+    - user.role.lt
     - user.role.mentee
     - user.role.mentor
     - user.role.professional_mentor
+    - user.role.ra
     - user.role.regional_expert
     - user.role.representative
     - user.role.research_computing_facilitator
     - user.role.research_software_engineer
     - user.role.researcher
+    - user.role.sc
     - user.role.steering_committee
     - user.role.student
   content:
@@ -1421,7 +1423,7 @@ display:
           contextual_filters_or: false
       relationships: {  }
       css_class: 'row mb-3 mx-2'
-      use_ajax: true
+      use_ajax: false
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -1583,8 +1585,6 @@ display:
             mentor: mentor
             professional_mentor: professional_mentor
             researcher: researcher
-            steering_committee: steering_committee
-            leadership: leadership
             representative: representative
             regional_expert: regional_expert
             research_computing_facilitator: research_computing_facilitator
@@ -1592,6 +1592,8 @@ display:
             ci_systems_engineer: ci_systems_engineer
             mentee: mentee
             domain_champion: domain_champion
+            sc: sc
+            lt: lt
           group: 1
           exposed: false
           expose:
@@ -1638,8 +1640,6 @@ display:
             mentor: mentor
             professional_mentor: professional_mentor
             researcher: researcher
-            steering_committee: steering_committee
-            leadership: leadership
             representative: representative
             regional_expert: regional_expert
             research_computing_facilitator: research_computing_facilitator
@@ -1647,6 +1647,8 @@ display:
             ci_systems_engineer: ci_systems_engineer
             mentee: mentee
             domain_champion: domain_champion
+            sc: sc
+            lt: lt
           group: 1
           exposed: true
           expose:
@@ -1683,6 +1685,19 @@ display:
               mentee: '0'
               student_champion: '0'
               domain_champion: '0'
+              cssn: '0'
+              affinity_group_leader: '0'
+              match_pm: '0'
+              sc: '0'
+              lt: '0'
+              ra: '0'
+              coco_pm: '0'
+              cnctci_pm: '0'
+              news_pm: '0'
+              kb_pm: '0'
+              careers_sc: '0'
+              ccmnet_pm: '0'
+              match_sc: '0'
             reduce: true
           is_grouped: false
           group_info:
@@ -1867,12 +1882,12 @@ display:
           value:
             student: student
             mentor: mentor
-            leadership: leadership
-            representative: representative
             research_computing_facilitator: research_computing_facilitator
             research_software_engineer: research_software_engineer
             ci_systems_engineer: ci_systems_engineer
             domain_champion: domain_champion
+            lt: lt
+            ra: ra
           group: 1
           exposed: false
           expose:
@@ -2192,11 +2207,11 @@ display:
             student: student
             mentor: mentor
             researcher: researcher
-            steering_committee: steering_committee
             regional_expert: regional_expert
             research_computing_facilitator: research_computing_facilitator
             research_software_engineer: research_software_engineer
             ci_systems_engineer: ci_systems_engineer
+            sc: sc
           group: 1
           exposed: false
           expose:
@@ -2516,13 +2531,13 @@ display:
             mentor: mentor
             professional_mentor: professional_mentor
             researcher: researcher
-            steering_committee: steering_committee
-            leadership: leadership
             representative: representative
             research_computing_facilitator: research_computing_facilitator
             research_software_engineer: research_software_engineer
             ci_systems_engineer: ci_systems_engineer
             mentee: mentee
+            sc: sc
+            lt: lt
           group: 1
           exposed: false
           expose:
@@ -2845,10 +2860,10 @@ display:
             mentor: mentor
             professional_mentor: professional_mentor
             researcher: researcher
-            steering_committee: steering_committee
             research_computing_facilitator: research_computing_facilitator
             research_software_engineer: research_software_engineer
             ci_systems_engineer: ci_systems_engineer
+            sc: sc
           group: 1
           exposed: false
           expose:
@@ -3169,10 +3184,10 @@ display:
             mentor: mentor
             professional_mentor: professional_mentor
             researcher: researcher
-            steering_committee: steering_committee
             research_computing_facilitator: research_computing_facilitator
             research_software_engineer: research_software_engineer
             ci_systems_engineer: ci_systems_engineer
+            sc: sc
           group: 1
           exposed: false
           expose:
@@ -3492,10 +3507,10 @@ display:
             student: student
             mentor: mentor
             researcher: researcher
-            steering_committee: steering_committee
             research_computing_facilitator: research_computing_facilitator
             research_software_engineer: research_software_engineer
             ci_systems_engineer: ci_systems_engineer
+            sc: sc
           group: 1
           exposed: false
           expose:
@@ -3815,12 +3830,12 @@ display:
             mentor: mentor
             professional_mentor: professional_mentor
             researcher: researcher
-            steering_committee: steering_committee
-            leadership: leadership
             representative: representative
             research_computing_facilitator: research_computing_facilitator
             research_software_engineer: research_software_engineer
             ci_systems_engineer: ci_systems_engineer
+            sc: sc
+            lt: lt
           group: 1
           exposed: false
           expose:
@@ -4139,14 +4154,7 @@ display:
           plugin_id: user_roles
           operator: or
           value:
-            student: student
-            mentor: mentor
-            professional_mentor: professional_mentor
-            researcher: researcher
-            steering_committee: steering_committee
-            research_computing_facilitator: research_computing_facilitator
-            research_software_engineer: research_software_engineer
-            ci_systems_engineer: ci_systems_engineer
+            sc: sc
           group: 1
           exposed: false
           expose:
@@ -4467,10 +4475,10 @@ display:
             mentor: mentor
             professional_mentor: professional_mentor
             researcher: researcher
-            steering_committee: steering_committee
             research_computing_facilitator: research_computing_facilitator
             research_software_engineer: research_software_engineer
             ci_systems_engineer: ci_systems_engineer
+            sc: sc
           group: 1
           exposed: false
           expose:


### PR DESCRIPTION
Filter by role on the people pages should use the new steering committee role (machine name sc).

How to test:
When I go to the people page, I should be able to filter by the “steering committee” role. Same for the list view.
Should test on multiple cyberteam domains since there are view displays for each domain. In the url after filtering, you should see the role machine name "sc" instead of "steering_committee" (which was the old machine name). You should see about 25 steering committee members.

https://md-1250-accessmatch.pantheonsite.io/people

JIRA issue:
https://cyberteamportal.atlassian.net/jira/software/c/projects/D8/boards/6?modal=detail&selectedIssue=D8-1250

Notes:
I also added longer names for the lt and ra roles.