### PR TITLE
access: 1.0.x-dev 5d19cf9 => dev-d8-1166 05ccffb - config: update fie…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "access/operations_cider": "dev-main",
         "acquia/blt": "^13.0",
         "acquia/blt-behat": "^1.3",
-        "amp/access": "1.0.x-dev",
+        "amp/access": "d8-1166-dev",
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "drupal/auditfiles": "^3.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9138e035c06e673d5dc48aa43e9bb49b",
+    "content-hash": "9100b5c57fde943d4859bb86528f8d70",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -289,13 +289,12 @@
         },
         {
             "name": "amp/access",
-            "version": "1.0.x-dev",
+            "version": "dev-d8-1166",
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/access.git",
-                "reference": "5d19cf90687fcd4261eaa8297b03b670a31342e2"
+                "reference": "05ccffba0e7fb2d7ef09e8247418abd9a914e2db"
             },
-            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "GPL-2.0+"
@@ -311,7 +310,7 @@
                 "issues": "https://github.com/necyberteam/access/issues",
                 "source": "https://github.com/necyberteam/access"
             },
-            "time": "2023-04-04T19:18:05+00:00"
+            "time": "2023-04-07T17:55:56+00:00"
         },
         {
             "name": "arthurkushman/query-path",

--- a/web/sites/default/config/default/field.storage.node.field_access_org_name.yml
+++ b/web/sites/default/config/default/field.storage.node.field_access_org_name.yml
@@ -11,7 +11,7 @@ field_name: field_access_org_name
 entity_type: node
 type: string
 settings:
-  max_length: 60
+  max_length: 300
   case_sensitive: false
   is_ascii: false
 module: core


### PR DESCRIPTION
…ld length d8-1166

hook_update that changes field length of node__field_access_org_name and node_revision__field_access_org_name.

This PR changes the config, you'll need to switch composer.json back to 1.0.x for the access module after merging this PR https://github.com/necyberteam/access/pull/69

https://cyberteamportal.atlassian.net/browse/D8-1166