### PR TITLE
Update allocations api and fix batch problems resulting in ajax-error crashes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "access/operations_cider": "dev-main",
     "acquia/blt": "^13.0",
     "acquia/blt-behat": "^1.3",
-    "amp/access": "1.0.x-dev",
+    "amp/access": "dev-new-alloc-api",
     "composer/installers": "^1.2",
     "cweagans/composer-patches": "^1.6",
     "drupal/auditfiles": "^3.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53c0e74457fc78325e25e43ccb6ed1b1",
+    "content-hash": "2d0b851199e17c2ed78e3362bc446eb6",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -289,13 +289,12 @@
         },
         {
             "name": "amp/access",
-            "version": "1.0.x-dev",
+            "version": "dev-new-alloc-api",
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/access.git",
-                "reference": "76508ec3b9be80fbe9ebb231090bd5db6d2c967b"
+                "reference": "1eb221ce4ad7cabc5f2a3c55d0145cc89d3fa09e"
             },
-            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "GPL-2.0+"
@@ -311,7 +310,7 @@
                 "issues": "https://github.com/necyberteam/access/issues",
                 "source": "https://github.com/necyberteam/access"
             },
-            "time": "2023-04-29T14:39:17+00:00"
+            "time": "2023-05-04T03:26:59+00:00"
         },
         {
             "name": "arthurkushman/query-path",


### PR DESCRIPTION
## Describe context / purpose for this PR
Update allocations api and fix batch problems resulting in ajax-error crashes
This is for the allocations users import.  API updates from the allocations were simple. 
The majority of the changes are to prevent the batches from crashing, which happened for 
3 reasons. The first 2 are hooks that we exit by adding a check if we are in the allocations process:
  redundant checking via an api call when creating a user, and  affinity group flagging. 
Third reason is using messanger, which are now avoided while in the allocations process.

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [x ] I have checked that the PR is ready to be merged
- [ x] I have reviewed the DIFF and checked that the changes are as expected
- [ x] I have assigned myself or someone else to review the PR
