### PR TITLE
d8-1496 - disabled suspended user check if local config is true

### DIFF
--- a/web/sites/default/config/local/user_profiles.settings.yml
+++ b/web/sites/default/config/local/user_profiles.settings.yml
@@ -1,0 +1,1 @@
+check_suspended_users: false


### PR DESCRIPTION
## Describe context / purpose for this PR
Create config to disable user_profile check for suspended users. Disable that check in local config_split.

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1496

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
