### PR TITLE
adding the dataLayer module (for GTM)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
     "drupal/core-recommended": "9.5.*",
     "drupal/csv_serialization": "^2.0",
     "drupal/ctools": "^3.4",
+    "drupal/datalayer": "^2.0@RC",
     "drupal/domain": "^1.0@beta",
     "drupal/domain_access": "^1.0@alpha",
     "drupal/domain_alias": "^1.0@alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "481536692358505bb1a3283b3385ce85",
+    "content-hash": "b769781850e7112aea2ef0a8f4cefd08",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -3877,6 +3877,76 @@
             "homepage": "https://www.drupal.org/project/ctools",
             "support": {
                 "source": "https://git.drupalcode.org/project/ctools"
+            }
+        },
+        {
+            "name": "drupal/datalayer",
+            "version": "2.0.0-rc1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/datalayer.git",
+                "reference": "2.0.0-rc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/datalayer-2.0.0-rc1.zip",
+                "reference": "2.0.0-rc1",
+                "shasum": "f7175ba5f77d3f8e601f9ae60e8b2a4572686b6a"
+            },
+            "require": {
+                "drupal/core": "^9.4 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-rc1",
+                    "datestamp": "1673987576",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "RC releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Josh Lind",
+                    "homepage": "https://www.drupal.org/u/doublejosh",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "blake.thompson",
+                    "homepage": "https://www.drupal.org/user/1803642"
+                },
+                {
+                    "name": "doublejosh",
+                    "homepage": "https://www.drupal.org/user/199720"
+                },
+                {
+                    "name": "eojthebrave",
+                    "homepage": "https://www.drupal.org/user/79230"
+                },
+                {
+                    "name": "josephdpurcell@gmail.com",
+                    "homepage": "https://www.drupal.org/user/2944035"
+                },
+                {
+                    "name": "WidgetsBurritos",
+                    "homepage": "https://www.drupal.org/user/2508346"
+                }
+            ],
+            "description": "Output page meta data for client-side availability.",
+            "homepage": "https://www.drupal.org/project/datalayer",
+            "keywords": [
+                "Data Layer",
+                "Drupal"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/datalayer",
+                "issues": "https://www.drupal.org/project/issues/datalayer"
             }
         },
         {
@@ -21976,6 +22046,7 @@
         "access/operations_cider": 20,
         "amp/access": 20,
         "drupal/auditfiles": 10,
+        "drupal/datalayer": 5,
         "drupal/domain": 10,
         "drupal/domain_access": 15,
         "drupal/domain_alias": 15,
@@ -22006,5 +22077,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## Describe context / purpose for this PR
Add datalayer to work with GTM (google tag manager) to be able to track people across sessions and devices. 

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-961

## Any other related PRs?
yes, for access: https://github.com/necyberteam/access/pull/91

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
