### PR TITLE
views: affinity_group memberslink taking down to 25 items

### DIFF
--- a/tests/behat/features/champ/champ-affinity-auth.feature
+++ b/tests/behat/features/champ/champ-affinity-auth.feature
@@ -41,6 +41,6 @@ Feature: test for the affinity groups page as an authenticated user
     Then I should see "Email"
     Then I should see "Coordinators"
     Then I should see "Events"
-    Then I should see "Resources"
+    Then I should see "CI Links"
     Then I should see "People"
     #Then I should see "Masquerade"

--- a/tests/behat/features/champ/champ-affinity-unauth.feature
+++ b/tests/behat/features/champ/champ-affinity-unauth.feature
@@ -26,7 +26,7 @@ Feature: test for the affinity groups page
     Then I should see "Email"
     Then I should see "Events"
     Then I should see "CI Links"
-    Then I should see "News"
+    Then I should see "Announcements"
     Then I should see "People"
 
 

--- a/tests/behat/features/champ/champ-affinity-unauth.feature
+++ b/tests/behat/features/champ/champ-affinity-unauth.feature
@@ -25,7 +25,7 @@ Feature: test for the affinity groups page
     Then I should see "Q&A"
     Then I should see "Email"
     Then I should see "Events"
-    Then I should see "Resources"
+    Then I should see "CI Links"
     Then I should see "News"
     Then I should see "People"
 

--- a/web/sites/default/config/default/views.view.affinity_group.yml
+++ b/web/sites/default/config/default/views.view.affinity_group.yml
@@ -380,7 +380,7 @@ display:
         type: full
         options:
           offset: 0
-          items_per_page: 0
+          items_per_page: 25
           total_pages: 1
           id: 0
           tags:

--- a/web/sites/default/config/default/views.view.affinity_group.yml
+++ b/web/sites/default/config/default/views.view.affinity_group.yml
@@ -4830,58 +4830,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        view_1:
-          id: view_1
-          table: views
-          field: view
-          relationship: none
-          group_type: group
-          admin_label: MemberLink
-          plugin_id: view
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: true
-          empty_zero: false
-          hide_alter_empty: true
-          view: affinity_group
-          display: block_1
-          arguments: '{{ raw_arguments.nid }}'
         field_resources_entity_reference:
           id: field_resources_entity_reference
           table: node__field_resources_entity_reference
@@ -5148,7 +5096,7 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
-          hide_empty: false
+          hide_empty: true
           empty_zero: false
           hide_alter_empty: true
           view: access_news
@@ -5394,7 +5342,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"card mb-3 border-0\">\r\n  <div class=\"card-body d-flex flex-column\">\r\n    <div class=\"float-md-right text-md-center mb-2\">\r\n    </div>\r\n    <div class=\"row\">\r\n      <div class=\"col-lg-4 col-md-8 mb-3\">\r\n        {% if field_image %}\r\n        <img src=\"{{ field_image }}\" class=\"img-fluid mb-4\">\r\n        {% else %}\r\n        <img src=\"/themes/nect-theme/img/neutral-images/affinity-groups-default.png\" class=\"img-fluid mb-4\">\r\n        {% endif %}\r\n        <div class=\"mt-auto\">Members get updates about news, events, and outages.</div>\r\n      </div>\r\n      <div class=\"col-lg-8 mb-3\">\r\n        <h1>{{ title }}</h1>\r\n        {% if field_tags %}\r\n        <i class=\"fa fa-tags pr-1\"></i>\r\n        {{ field_tags }}\r\n        {% endif %}\r\n        <div class=\"my-3\">{{ body }}</div>\r\n      </div>\r\n    </div>\r\n\r\n    <div class=\"row mb-3\">\r\n      <div class=\"col-12 d-flex justify-content-start flex-wrap\">        \r\n        {% if flagged %}\r\n        <div class=\"bg-orange btn cursor-default text-white m-2\">\r\n            <i class=\"fa-solid fa-badge-check\"></i> Member\r\n        </div>\r\n        {% endif %}\r\n        {% if link_flag %}\r\n        <div class=\"affinity-group-flag m-2\">{{ link_flag }}</div>\r\n        {% else %}\r\n        <a href=\"/user\" class=\"btn btn-secondary disabled m-2\" disabled>Join</a>\r\n        {% endif %}        \r\n        {% if field_slack %}\r\n        <a href=\"{{ field_slack }}\" target=\"_blank\" class=\"btn btn-primary m-2\">Slack</a>\r\n        {% endif %}\r\n        {% if field_ask_ci_locale %}\r\n        <a href=\"{{ field_ask_ci_locale }}\" target=\"_blank\" class=\"btn btn-primary m-2\">Q&amp;A</a>\r\n        {% endif %}\r\n        {% if field_github_organization %}\r\n        <a href=\"{{ field_github_organization }}\" target=\"_blank\" class=\"btn btn-primary m-2\" >GitHub</a>\r\n        {% endif %}\r\n        {% if field_mailing_list %}\r\n        {% if view_3 %}<a href=\"{{ field_mailing_list }}\" target=\"_blank\" class=\"btn btn-primary m-2\"  style=\"width: fit-content\">Email</a>{% else %}<a href=\"#\" target=\"_blank\" class=\"btn btn-secondary btn-block border-0 disabled m-2\" disabled>Email</a>{% endif %}\r\n        {% endif %}\r\n      </div>\r\n    </div>\r\n\r\n    <div class=\"row my-3\">\r\n      <div class=\"col-md-4 d-flex flex-column\">\r\n        {% if field_cider_resources %}\r\n        <section id=\"cider-resources\" class=\"mb-3\">\r\n            <h3 class=\"border-bottom pb-2\">Associated Infrastructure</h3>\r\n            {{ field_cider_resources }}\r\n        </section>\r\n        {% endif %}\r\n        <section id=\"coordinators\" class=\"mb-3\">\r\n        <h3 class=\"border-bottom pb-2\">Coordinators</h3>\r\n        {% if field_coordinator %}\r\n        <ul class=\"list-unstyled\">\r\n          {{ field_coordinator }}\r\n        </ul>\r\n        {% else %}\r\n          <p>No coordinators have been added.</p>\r\n        {% endif %}\r\n        </section>\r\n        <section id=\"events\" class=\"my-3\">\r\n          <h3 class=\"border-bottom pb-2\">Events</h3>\r\n          {% if view_4 %}{{ view_4 }}{% endif %}\r\n      </div>\r\n      <div class=\"col-md-8 d-flex flex-column\">\r\n          {% if nothing %}\r\n            <section id=\"cider_resources\" class=\"mb-3\">\r\n              {{ nothing }} \r\n            </section>\r\n          {% endif %}\r\n        <section id=\"resources\" class=\"mb-3\">\r\n          <h3 class=\"border-bottom pb-2\">Resources</h3>\r\n          {% if view_2 %}\r\n            {{ view_2 }}\r\n          {% else %}\r\n            <p>There are no resources at this time. Please check back later or visit the <a href=\"/resources\">All Resources</a> page.</p>\r\n          {% endif %}\r\n        </section>\r\n       <section id=\"access_news\" class=\"mb-3\">\r\n          <h3 class=\"border-bottom pb-2\">News</h3>\r\n          {% if view_6 %}\r\n            {{ view_6 }}\r\n          {% else %}\r\n            <p>There is no news at this time. Please check back later or visit the <a href=\"/news\">News</a> page.</p>\r\n          {% endif %}\r\n        </section>\r\n      </div>\r\n    </div>\r\n  </div>\r\n</div>"
+            text: "<div class=\"card mb-3 border-0\">\r\n  <div class=\"card-body d-flex flex-column\">\r\n    <div class=\"float-md-right text-md-center mb-2\">\r\n    </div>\r\n    <div class=\"row\">\r\n      <div class=\"col-lg-4 col-md-8 mb-3\">\r\n        {% if field_image %}\r\n        <img src=\"{{ field_image }}\" class=\"img-fluid mb-4\">\r\n        {% else %}\r\n        <img src=\"/themes/nect-theme/img/neutral-images/affinity-groups-default.png\" class=\"img-fluid mb-4\">\r\n        {% endif %}\r\n        <div class=\"mt-auto\">Members get updates about announcements, events, and outages.</div>\r\n      </div>\r\n      <div class=\"col-lg-8 mb-3\">\r\n        <h1>{{ title }}</h1>\r\n        {% if field_tags %}\r\n        <i class=\"fa fa-tags pr-1\"></i>\r\n        {{ field_tags }}\r\n        {% endif %}\r\n        <div class=\"my-3\">{{ body }}</div>\r\n      </div>\r\n    </div>\r\n\r\n    <div class=\"row mb-3\">\r\n      <div class=\"col-12 d-flex justify-content-start flex-wrap\">        \r\n        {% if flagged %}\r\n        <div class=\"bg-orange btn cursor-default text-white m-2\">\r\n            <i class=\"fa-solid fa-badge-check\"></i> Member\r\n        </div>\r\n        {% endif %}\r\n        {% if link_flag %}\r\n        <div class=\"affinity-group-flag m-2\">{{ link_flag }}</div>\r\n        {% else %}\r\n        <a href=\"/user\" class=\"btn btn-secondary disabled m-2\" disabled>Join</a>\r\n        {% endif %}        \r\n        {% if field_slack %}\r\n        <a href=\"{{ field_slack }}\" target=\"_blank\" class=\"btn btn-primary m-2\">Slack</a>\r\n        {% endif %}\r\n        {% if field_ask_ci_locale %}\r\n        <a href=\"{{ field_ask_ci_locale }}\" target=\"_blank\" class=\"btn btn-primary m-2\">Q&amp;A</a>\r\n        {% endif %}\r\n        {% if field_github_organization %}\r\n        <a href=\"{{ field_github_organization }}\" target=\"_blank\" class=\"btn btn-primary m-2\" >GitHub</a>\r\n        {% endif %}\r\n        {% if field_mailing_list %}\r\n        {% if view_3 %}<a href=\"{{ field_mailing_list }}\" target=\"_blank\" class=\"btn btn-primary m-2\"  style=\"width: fit-content\">Email</a>{% else %}<a href=\"#\" target=\"_blank\" class=\"btn btn-secondary btn-block border-0 disabled m-2\" disabled>Email</a>{% endif %}\r\n        {% endif %}\r\n      </div>\r\n    </div>\r\n\r\n    <div class=\"row my-3\">\r\n      <div class=\"col-md-4 d-flex flex-column\">\r\n        {% if field_cider_resources %}\r\n        <section id=\"cider-resources\" class=\"mb-3\">\r\n            <h3 class=\"border-bottom pb-2\">Associated Infrastructure</h3>\r\n            {{ field_cider_resources }}\r\n        </section>\r\n        {% endif %}\r\n        <section id=\"coordinators\" class=\"mb-3\">\r\n        <h3 class=\"border-bottom pb-2\">Coordinators</h3>\r\n        {% if field_coordinator %}\r\n        <ul class=\"list-unstyled\">\r\n          {{ field_coordinator }}\r\n        </ul>\r\n        {% else %}\r\n          <p>No coordinators have been added.</p>\r\n        {% endif %}\r\n        </section>\r\n        <section id=\"events\" class=\"my-3\">\r\n          <h3 class=\"border-bottom pb-2\">Events</h3>\r\n          {% if view_4 %}{{ view_4 }}{% endif %}\r\n      </div>\r\n      <div class=\"col-md-8 d-flex flex-column\">\r\n          {% if nothing %}\r\n            <section id=\"cider_resources\" class=\"mb-3\">\r\n              {{ nothing }} \r\n            </section>\r\n          {% endif %}\r\n        <section id=\"resources\" class=\"mb-3\">\r\n          <h3 class=\"border-bottom pb-2\">CI Links</h3>\r\n          {% if view_2 %}\r\n            {{ view_2 }}\r\n          {% else %}\r\n            <p>There are no CI Links at this time. Please check back later or visit the <a href=\"/ci-links\">CI Links</a> page.</p>\r\n          {% endif %}\r\n        </section>\r\n       <section id=\"access_news\" class=\"mb-3\">\r\n          <h3 class=\"border-bottom pb-2\">Announcements</h3>\r\n          {% if view_6 %}\r\n            {{ view_6 }}\r\n          {% else %}\r\n            <p>There are no announcements at this time. Please check back later or visit the <a href=\"/announcements\">Announcements</a> page.</p>\r\n          {% endif %}\r\n        </section>\r\n      </div>\r\n    </div>\r\n  </div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false

--- a/web/sites/default/config/default/views.view.affinity_group.yml
+++ b/web/sites/default/config/default/views.view.affinity_group.yml
@@ -380,7 +380,7 @@ display:
         type: full
         options:
           offset: 0
-          items_per_page: 25
+          items_per_page: 0
           total_pages: 1
           id: 0
           tags:


### PR DESCRIPTION
## Describe context / purpose for this PR

Fix access groups for coordinators that try go view pages they are coordinators of not loading. I changed the members link view to show 25 items instead of unlimited.

## Issue link

https://cyberteamportal.atlassian.net/jira/software/c/projects/D8/issues/D8-1510

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
