### PR TITLE
Cleanup obsolete ciders + working form for affinity group sync

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "access/operations_cider": "dev-main",
     "acquia/blt": "^13.0",
     "acquia/blt-behat": "^1.3",
-    "amp/access": "dev-d8-1496--local-disable-suspended-user-check-access",
+    "amp/access": "dev-d8-cleanup-alloc-ciders",
     "composer/installers": "^1.2",
     "cweagans/composer-patches": "^1.6",
     "drupal/auditfiles": "^3.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "481536692358505bb1a3283b3385ce85",
+    "content-hash": "a0a5dd6d5f67a21c93915ec0d8ef3a9e",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -289,11 +289,11 @@
         },
         {
             "name": "amp/access",
-            "version": "dev-d8-1496--local-disable-suspended-user-check-access",
+            "version": "dev-d8-cleanup-alloc-ciders",
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/access.git",
-                "reference": "ccc15482551bebfcc8cbe8792cfc277f8ab5312d"
+                "reference": "40485d5ee43d45593e9e6ba658a52fd52cfae90e"
             },
             "type": "drupal-custom-module",
             "license": [
@@ -310,7 +310,7 @@
                 "issues": "https://github.com/necyberteam/access/issues",
                 "source": "https://github.com/necyberteam/access"
             },
-            "time": "2023-05-11T20:03:56+00:00"
+            "time": "2023-05-16T15:58:41+00:00"
         },
         {
             "name": "arthurkushman/query-path",


### PR DESCRIPTION
## Describe context / purpose for this PR
- process to clean up allocation cider lists on user profiles when user  no longer has allocations.  We get all the active users from the allocations api, which will not include previously added users allocations.
- also includes a code omission from previous commit regard allocations api for the Constant Contact form.  This form has 2 new submit buttons: one to sync the affinity groups with constant contact email lists (when users are added without CC being actively hooked up)  and one for this obsolete allocations cleanup described above.

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1519

## Any other related PRs?
https://github.com/necyberteam/access/pull/92

## Link to MultiDev instance
https://md-obscider-accessmatch.pantheonsite.io/

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
