### PR TITLE
cssn_members view: add admin role and show user roles d8-1502

### DIFF
--- a/web/sites/default/config/default/views.view.cssn_members.yml
+++ b/web/sites/default/config/default/views.view.cssn_members.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.user.field_institution
+    - user.role.administrator
     - user.role.match_pm
     - webform.webform.join_the_cssn_network
   module:
@@ -199,6 +200,59 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        roles_target_id:
+          id: roles_target_id
+          table: user__roles
+          field: roles_target_id
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: roles
+          plugin_id: user_roles
+          label: 'User''s Current Roles'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: separator
+          separator: ', '
         webform_submission_value:
           id: webform_submission_value
           table: webform_submission_field_join_the_cssn_network_i_am_joining_as_a_
@@ -414,6 +468,7 @@ display:
         type: role
         options:
           role:
+            administrator: administrator
             match_pm: match_pm
       cache:
         type: tag
@@ -648,6 +703,59 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        roles_target_id:
+          id: roles_target_id
+          table: user__roles
+          field: roles_target_id
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: roles
+          plugin_id: user_roles
+          label: 'User''s Current Roles'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: separator
+          separator: ', '
         webform_submission_value:
           id: webform_submission_value
           table: webform_submission_field_join_the_cssn_network_i_am_joining_as_a_


### PR DESCRIPTION
## Describe context / purpose for this PR
Add roles to CSSN export and add "administrator" role to the view.

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1502

## Any other related PRs?
n/a

## Link to MultiDev instance
http://md-1502-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
