### PR TITLE
On Affinity groups, hide title d8-1719

### DIFF
--- a/web/themes/custom/accesstheme/scss/style.scss
+++ b/web/themes/custom/accesstheme/scss/style.scss
@@ -798,6 +798,11 @@ ul.sf-menu {
     }
   }
 
+  // affinity group title; on this theme, displays in title bar
+  h1.block-field-blocknodeaffinity-grouptitle {
+    display: none;
+  }
+
   #block-views-block-recurring-events-event-instances-block-1,
   #block-views-block-recurring-events-event-instances-block-2 {
     padding-top: 14px;


### PR DESCRIPTION
On Affinity groups, Hide regular title for Access
theme.  Other portals need this title line, but
for Access, it already shows up in green title bar.

## Describe context / purpose for this PR

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1719

## Any other related PRs?
no 

## Link to MultiDev instance

http://md-1719-accessmatch.pantheonsite.io

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
