### PR TITLE
Affinity group events display fixes  - md-1856

### DIFF
--- a/tests/behat/features/asp/affinity-groups/affinity_groups-individual.feature
+++ b/tests/behat/features/asp/affinity-groups/affinity_groups-individual.feature
@@ -69,7 +69,8 @@ Feature: Feature: test an Affinity Groups page
     Given I am not logged in
     When I am on "/affinity-groups/access-support"
     Then I should see "Events"
-    Then I should see "[4/04/2023 7:00 PM EDT]"
+    # TODO need a future event for the following
+    # Then I should see "[4/04/2023 7:00 PM EDT]"
     Then link "How to Write a Successful" should contain "/events/6593"
     # TODO - once able to add a CI Link to this AG, uncomment the following
     #Then I should see "ci-link-for-user-200"

--- a/tests/behat/features/asp/affinity-groups/affinity_groups-individual.feature
+++ b/tests/behat/features/asp/affinity-groups/affinity_groups-individual.feature
@@ -71,12 +71,12 @@ Feature: Feature: test an Affinity Groups page
     Then I should see "Events"
     # TODO need a future event for the following
     # Then I should see "[4/04/2023 7:00 PM EDT]"
-    Then link "How to Write a Successful" should contain "/events/6593"
+    # Then link "How to Write a Successful" should contain "/events/6593"
     # TODO - once able to add a CI Link to this AG, uncomment the following
     #Then I should see "ci-link-for-user-200"
     Then link "Changing my user profile name on the" should contain "/t/changing-my-user-profile-name-on-the-access-support-portal/2479"
-    When I click "How to Write a Successful"
-    Then I should be on "/events/6593"
+    #When I click "How to Write a Successful"
+    #Then I should be on "/events/6593"
 
 
   Scenario: Unauthenticated user tests an AG with an announcement

--- a/tests/behat/features/templates/affinity_groups/affinity_group.feature
+++ b/tests/behat/features/templates/affinity_groups/affinity_group.feature
@@ -72,7 +72,7 @@ Feature: Feature: test an Affinity Groups page
     Then I should see "Events"
     # TODO need a future event for the following
     # Then I should see "[4/04/2023 7:00 PM EDT]"
-    Then link "How to Write a Successful" should contain "/events/6593"
+    # Then link "How to Write a Successful" should contain "/events/6593"
     # TODO - once able to add a CI Link to this AG, uncomment the following
     #Then I should see "ci-link-for-user-200"
     Then link "Changing my user profile name on the" should contain "/t/changing-my-user-profile-name-on-the-access-support-portal/2479"

--- a/tests/behat/features/templates/affinity_groups/affinity_group.feature
+++ b/tests/behat/features/templates/affinity_groups/affinity_group.feature
@@ -76,8 +76,8 @@ Feature: Feature: test an Affinity Groups page
     # TODO - once able to add a CI Link to this AG, uncomment the following
     #Then I should see "ci-link-for-user-200"
     Then link "Changing my user profile name on the" should contain "/t/changing-my-user-profile-name-on-the-access-support-portal/2479"
-    When I click "How to Write a Successful"
-    Then I should be on "/events/6593"
+    #When I click "How to Write a Successful"
+    #Then I should be on "/events/6593"
 
 
   Scenario: Unauthenticated user tests an AG with an announcement

--- a/tests/behat/features/templates/affinity_groups/affinity_group.feature
+++ b/tests/behat/features/templates/affinity_groups/affinity_group.feature
@@ -70,7 +70,8 @@ Feature: Feature: test an Affinity Groups page
     Given I am not logged in
     When I am on "/affinity-groups/access-support"
     Then I should see "Events"
-    Then I should see "[4/04/2023 7:00 PM EDT]"
+    # TODO need a future event for the following
+    # Then I should see "[4/04/2023 7:00 PM EDT]"
     Then link "How to Write a Successful" should contain "/events/6593"
     # TODO - once able to add a CI Link to this AG, uncomment the following
     #Then I should see "ci-link-for-user-200"

--- a/web/sites/default/config/default/views.view.affinity_group_recurring_events.yml
+++ b/web/sites/default/config/default/views.view.affinity_group_recurring_events.yml
@@ -299,7 +299,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "{# split off first value of times range in date__value__1 (instance_time) #}\r\n{% set split_times =  date__value_1|split('*') %}\r\n[{{ date__value }} {{split_times[0]}}] <a href=\"{{ view_eventinstance }}\">{{ title }}</a>"
+            text: "{# split off first value of times range in date__value__1 (instance_time) #}\r\n{% set split_times =  date__value_1|split('*') %}\r\n[{{ date__value }} {{split_times[0]|trim}}] <a href=\"{{ view_eventinstance }}\">{{ title }}</a>"
             make_link: false
             path: ''
             absolute: false

--- a/web/sites/default/config/default/views.view.affinity_group_recurring_events.yml
+++ b/web/sites/default/config/default/views.view.affinity_group_recurring_events.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.eventseries.field_affinity_group
   module:
+    - datetime
     - datetime_range
     - recurring_events
 id: affinity_group_recurring_events
@@ -151,6 +152,73 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        date__value_1:
+          id: date__value_1
+          table: eventinstance_field_data
+          field: date__value
+          relationship: event_instances_target_id
+          group_type: group
+          admin_label: instance_time
+          entity_type: eventinstance
+          entity_field: date
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: daterange_custom
+          settings:
+            timezone_override: ''
+            date_format: 'g:i A T'
+            separator: '*'
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         date__value:
           id: date__value
           table: eventinstance_field_data
@@ -165,7 +233,7 @@ display:
           exclude: true
           alter:
             alter_text: true
-            text: '[{{ date__value__value|date(''n/d/Y g:i A T'')}}]'
+            text: '{{ date__value__value|date(''n/d/Y'')}}'
             make_link: false
             path: ''
             absolute: false
@@ -206,7 +274,7 @@ display:
           type: daterange_custom
           settings:
             timezone_override: ''
-            date_format: 'M/d/Y - g:iA'
+            date_format: 'Y-m-d\TH:i:s'
             separator: '-'
           group_column: value
           group_columns: {  }
@@ -231,7 +299,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: ' {{ date__value }} <a href="{{ view_eventinstance }}">{{ title }}</a>'
+            text: "{# split off first value of times range in date__value__1 (instance_time) #}\r\n{% set split_times =  date__value_1|split('*') %}\r\n[{{ date__value }} {{split_times[0]}}] <a href=\"{{ view_eventinstance }}\">{{ title }}</a>"
             make_link: false
             path: ''
             absolute: false
@@ -293,7 +361,23 @@ display:
         type: tag
         options: {  }
       empty: {  }
-      sorts: {  }
+      sorts:
+        date__value:
+          id: date__value
+          table: eventinstance_field_data
+          field: date__value
+          relationship: event_instances_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: eventinstance
+          entity_field: date
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: 'Event Date'
+            field_identifier: date__value
+          exposed: false
+          granularity: minute
       arguments:
         field_affinity_group_target_id:
           id: field_affinity_group_target_id
@@ -345,6 +429,54 @@ display:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
+        date__value:
+          id: date__value
+          table: eventinstance_field_data
+          field: date__value
+          relationship: event_instances_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: eventinstance
+          entity_field: date
+          plugin_id: datetime
+          operator: '>'
+          value:
+            min: ''
+            max: ''
+            value: '-12 hours'
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          use_tokens: false
       style:
         type: default
         options:


### PR DESCRIPTION
On Affinity group display, correct time for events listed, sort, filter off bygone events.
Changes View rewrite.  
## Describe context / purpose for this PR

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1856

## Any other related PRs? no

## Link to MultiDev instance
http://md-1856-accessmatch.pantheonsite.io

## Checklist for PR author
- [x ] I have checked that the PR is ready to be merged
- [x ] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
