### PR TITLE
D8 1587 - Update Campus Champions Stats

### DIFF
--- a/web/modules/custom/campuschampions/campuschampions.module
+++ b/web/modules/custom/campuschampions/campuschampions.module
@@ -316,55 +316,19 @@ function campuschampions_views_data_export_row_alter(&$row, \Drupal\views\Result
       $row['field_carnegie_code_classification'] = $results['BASIC2021'];
       $row['field_carnegie_code_msi'] = $results['MSI'];
       $row['field_carnegie_code_site'] = $results['NAME'];
-      $row['field_carnegie_code_eps_lookup'] = 0;
+      $row['field_carnegie_code_region'] = CarnegieCodesLookup::region($results['STABBR']);
 
-      $epscor = array(
-        'AK', 'AL', 'AR', 'DE', 'GU', 'HI', 'ID',
-        'KS', 'KY', 'LA', 'ME', 'MS', 'MT', 'ND',
-        'NE', 'NH', 'NM', 'NV', 'OK', 'PR', 'RI',
-        'SC', 'SD', 'VI', 'VT', 'WV', 'WY',
-      );
-      if (in_array($results['STABBR'], $epscor)) {
+      $row['field_carnegie_code_eps_lookup'] = 0;
+      if (CarnegieCodesLookup::isEpscor($results['STABBR'])) {
         $row['field_carnegie_code_eps_lookup'] = 1;
       }
 
-      // type_id = MSI + 10 * EPS_lookup + 100 * non-academy
-      $nonacademy = 0;
-      if (is_numeric($cc)) {
-        $nonacademy = $cc > 9999 ? 0 : 1;
-      }
-      $row['field_carnegie_code_type_id'] = ($row['field_carnegie_code_msi'] + 10) * $row['field_carnegie_code_eps_lookup'] + (100 * $nonacademy);
-
-      switch ($row['field_carnegie_code_type_id'])
-      {
-        case 110:
-        case 100: $row['field_carnegie_code_type'] = 'other not-for-profit organization'; break;
-        case 11:  $row['field_carnegie_code_type'] = 'MSI in EPSCoR jurisdiction';        break;
-        case 10:  $row['field_carnegie_code_type'] = 'EPSCoR';                            break;
-        case 1:   $row['field_carnegie_code_type'] = 'Minority Serving Institution';      break;
-        case 0:
-        default:  $row['field_carnegie_code_type'] = 'Academic institution';
-      }
-
-      $regions = array(
-        'AK' => 1, 'AL' => 5, 'AR' => 4, 'AZ' => 2,
-        'CA' => 2, 'CO' => 8, 'CT' => 7, 'DC' => 6,
-        'DE' => 6, 'FL' => 5, 'GA' => 5, 'HI' => 2,
-        'IA' => 3, 'ID' => 1, 'IL' => 3, 'IN' => 6,
-        'KS' => 4, 'KY' => 6, 'LA' => 4, 'MA' => 7,
-        'MD' => 6, 'ME' => 7, 'MI' => 6, 'MN' => 3,
-        'MO' => 4, 'MS' => 5, 'MT' => 1, 'NC' => 5,
-        'ND' => 3, 'NE' => 4, 'NH' => 7, 'NJ' => 6,
-        'NM' => 8, 'NV' => 2, 'NY' => 7, 'OH' => 6,
-        'OK' => 4, 'OR' => 1, 'PA' => 6, 'PR' => 5,
-        'RI' => 7, 'SC' => 5, 'SD' => 3, 'TN' => 5,
-        'TX' => 4, 'UT' => 8, 'VA' => 6, 'VI' => 5,
-        'VT' => 7, 'WA' => 1, 'WI' => 3, 'WV' => 6,
-        'WY' => 8, 'GU' => 2,
+      $row['field_carnegie_code_type_id'] = CarnegieCodesLookup::typeId(
+        $row['field_carnegie_code_msi'],
+        $row['field_carnegie_code_eps_lookup'],
+        $row['field_carnegie_code']
       );
-      if (isset($regions[$results['STABBR']])) {
-        $row['field_carnegie_code_region'] = $regions[$results['STABBR']];
-      }
+      $row['field_carnegie_code_type'] = CarnegieCodesLookup::type($row['field_carnegie_code_type_id']);
 
       // Try to retrieve the LAT and LON from the ACCESS organization
       $nids = \Drupal::entityQuery('node')

--- a/web/modules/custom/campuschampions/js/campuschampions.js
+++ b/web/modules/custom/campuschampions/js/campuschampions.js
@@ -1,10 +1,21 @@
-setTimeout(function() {
-    const nationwide = document.getElementById("cc-nationwide");
-    nationwide.innerHTML = 827;
-    const institutions = document.getElementById("cc-institutions");
-    institutions.innerHTML = 362;
-    const epscor = document.getElementById("cc-epscor");
-    epscor.innerHTML = 87;
-    const msi = document.getElementById("cc-msi");
-    msi.innerHTML = 61;
-}, 0);
+document.addEventListener('DOMContentLoaded', function () {
+    const nationwide = document.getElementById('cc-nationwide');
+    if (nationwide) {
+        nationwide.innerHTML = nationwide.getAttribute('data-value');
+    }
+
+    const institutions = document.getElementById('cc-institutions');
+    if (institutions) {
+        institutions.innerHTML = institutions.getAttribute('data-value');
+    }
+
+    const epscor = document.getElementById('cc-epscor');
+    if (epscor) {
+        epscor.innerHTML = epscor.getAttribute('data-value');
+    }
+
+    const msi = document.getElementById('cc-msi');
+    if (msi) {
+        msi.innerHTML = msi.getAttribute('data-value');
+    }
+});

--- a/web/modules/custom/campuschampions/src/Commands/CampusChampionsCommands.php
+++ b/web/modules/custom/campuschampions/src/Commands/CampusChampionsCommands.php
@@ -6,6 +6,8 @@ use Drush\Commands\DrushCommands;
 use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\Component\Utility\SafeMarkup;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\campuschampions\Plugin\CarnegieCodesLookup;
 
 /**
  * A Drush commandfile for Campus Champions.
@@ -13,7 +15,6 @@ use Drupal\Component\Utility\Html;
  */
 class CampusChampionsCommands extends DrushCommands
 {
-
     /**
      * Drush command that exports affinity groups and emails the csv report.
      *
@@ -31,10 +32,10 @@ class CampusChampionsCommands extends DrushCommands
         $host = \Drupal::request()->getHost(); // specified as uri parameter in the command
 
         $nids = \Drupal::entityQuery('node')
-        ->condition('status', 1)
-        ->condition('type', 'affinity_group')
-        ->accessCheck(FALSE)
-        ->execute();
+            ->condition('status', 1)
+            ->condition('type', 'affinity_group')
+            ->accessCheck(FALSE)
+            ->execute();
         $nodes = \Drupal\node\Entity\Node::loadMultiple($nids);
 
         foreach ($nodes as $affinityGroup) {
@@ -46,7 +47,7 @@ class CampusChampionsCommands extends DrushCommands
             $output = \Drupal::service('renderer')->renderPlain($rendered);
 
             $filename = 'affinity-groups/affinity_group_' . $affinityGroup->getTitle() . '_'. date('Y_m_d') . '.csv';
-            $filepath = "sites/default/files/{$filename}";
+            $filepath = "sites/default/files/" . $filename;
             file_unmanaged_save_data($output, "public://{$filename}", FILE_EXISTS_REPLACE);
 
             array_push($reports, (object)[
@@ -74,6 +75,7 @@ $report_list . '
 </html>
 ';
         $this->output()->writeln($message);
+
         $headers[] = 'MIME-Version: 1.0';
         $headers[] = 'Content-type: text/html; charset=iso-8859-1';
         $headers[] = 'From: ' . $from_email;
@@ -81,4 +83,133 @@ $report_list . '
         mail($to_email, $subject, $message, implode("\r\n", $headers), $parameters);
     }
 
+    /**
+     * Drush command that generates the stats used on the front page
+     *
+     * @command campuschampions:generateBreakdownStats
+     * @aliases drush-cc breakdown-stats
+     * @usage campuschampions:generateBreakdownStats
+     */
+    public function generateBreakdownStats($options = array()) {
+        $dir = 'public://';
+        $file = 'cc-breakdown-stats.json';
+        $path = $dir . $file;
+
+        $data = [
+            // Champions natiowide
+            'nationwide' => 0,
+            // Institutions Represented
+            'institutions' => 0,
+            // Estab­lished Program to Stim­u­late Com­pet­i­tive Research
+            'epscor' => 0,
+            // Minority Serving Institutes
+            'msi' => 0
+        ];
+
+        $region = 572; // Campus Champions
+
+        // Nation wide
+        $query = \Drupal::database()
+            ->select('users_field_data', 'f')
+            ->fields('f', ['uid']);
+        $query->innerJoin('user__field_region', 'n', 'n.entity_id = f.uid');
+        $query->condition('n.deleted', 0);
+        $query->condition('n.field_region_target_id', $region);
+        $query->condition('f.status', 1);
+
+        $data['nationwide'] = $query->countQuery()
+            ->execute()
+            ->fetchField();
+
+        // Institutions
+        $query = \Drupal::database()
+            ->select('user__field_institution', 'i')
+            ->fields('i', ['field_institution_value']);
+        $query->innerJoin('users_field_data', 'f', 'i.entity_id = f.uid');
+        $query->innerJoin('user__field_region', 'n', 'n.entity_id = f.uid');
+        $query->condition('i.deleted', 0);
+        $query->condition('n.deleted', 0);
+        $query->condition('n.field_region_target_id', $region);
+        $query->condition('f.status', 1);
+
+        $data['institutions'] = $query->distinct()
+            ->countQuery()
+            ->execute()
+            ->fetchField();
+
+        // EPSCoR states
+        $query = \Drupal::database()
+            ->select('user__field_carnegie_code', 'c')
+            ->fields('c', ['field_carnegie_code_value']);
+        $query->innerJoin('users_field_data', 'f', 'c.entity_id = f.uid');
+        $query->innerJoin('user__field_region', 'n', 'n.entity_id = f.uid');
+        $query->innerJoin('carnegie_codes', 'r', 'r.unitid = c.field_carnegie_code_value');
+        $query->condition('n.deleted', 0);
+        $query->condition('n.field_region_target_id', $region);
+        $query->condition('f.status', 1);
+        $query->condition('r.stabbr', CarnegieCodesLookup::EPSCOR_STATES, 'IN');
+
+        $data['epscor'] = $query->distinct()
+            ->countQuery()
+            ->execute()
+            ->fetchField();
+
+        // MSI
+        $query = \Drupal::database()
+            ->select('user__field_carnegie_code', 'c')
+            ->fields('c', ['field_carnegie_code_value']);
+        $query->innerJoin('users_field_data', 'f', 'c.entity_id = f.uid');
+        $query->innerJoin('user__field_region', 'n', 'n.entity_id = f.uid');
+        $query->innerJoin('carnegie_codes', 'r', 'r.unitid = c.field_carnegie_code_value');
+        $query->condition('n.deleted', 0);
+        $query->condition('n.field_region_target_id', $region);
+        $query->condition('f.status', 1);
+        $query->condition('r.msi', 1);
+
+        $data['msi'] = $query->distinct()->countQuery()->execute()->fetchField();
+
+        // Write the data to a file
+        $fileSystem = \Drupal::service('file_system');
+
+        if (!$fileSystem->prepareDirectory($dir, FileSystemInterface::CREATE_DIRECTORY)) {
+            if ($options['verbose']) {
+                $this->output()->writeln('<error>Failed to prepare destination directory.</error>');
+            }
+            return;
+        }
+
+        $fileRepository = \Drupal::service('file.repository');
+        $result = $fileRepository->writeData(
+            json_encode($data),
+            $path,
+            FileSystemInterface::EXISTS_REPLACE
+        );
+
+        if (!$result) {
+            if ($options['verbose']) {
+                $this->output()->writeln('<error>Failed to write file.</error>');
+            }
+            return;
+        }
+
+        // If NOT verbose, we don't really need to go beyond this point
+        if (!$options['verbose']) {
+            return;
+        }
+
+        $realpath = $fileSystem->realpath($dir) . '/' . $file;
+        $this->output()->writeln('<info>Generated JSON file at ' . $realpath . '</info>');
+
+        $o = array();
+        foreach ($data as $key => $val) {
+            $o[] = [$key, number_format($val)];
+        }
+
+        // Summary table
+        $this->output()->writeln('');
+        $this->io()->table(
+            ['Type', 'Count'],
+            $o
+        );
+    }
 }

--- a/web/modules/custom/campuschampions/src/Controller/JsonApiCCController.php
+++ b/web/modules/custom/campuschampions/src/Controller/JsonApiCCController.php
@@ -30,12 +30,10 @@ class JsonApiCCController {
         $rows = $query->execute();
         foreach ($rows as $row) {
             $results[] = [
-            'label' => $row->NAME,
-            'value' => $row->UNITID
+                'label' => $row->NAME,
+                'value' => $row->UNITID
             ];
         }
         return new JsonResponse($results);
-    }  
+    }
 }
-
-?>

--- a/web/modules/custom/campuschampions/src/Plugin/Block/CampusChampionsBlock.php
+++ b/web/modules/custom/campuschampions/src/Plugin/Block/CampusChampionsBlock.php
@@ -19,9 +19,26 @@ class CampusChampionsBlock extends BlockBase {
    * {@inheritdoc}
    */
   public function build() {
+    $stats = [
+      'nationwide' => 827,
+      'institutions' => 362,
+      'epscor' => 87,
+      'msi' => 61
+    ];
+
+    $file = \Drupal::service('file_system')->realpath('public://') . '/cc-breakdown-stats.json';
+
+    if (file_exists($file)) {
+      $contents = file_get_contents($file);
+      $data = json_decode($contents);
+      if (!empty($data)) {
+        $stats = $data;
+      }
+    }
+
     return [
       '#theme' => 'campuschampions_block',
-      '#data' => [],
+      '#data' => $stats,
     ];
   }
 

--- a/web/modules/custom/campuschampions/src/Plugin/CarnegieCodesLookup.php
+++ b/web/modules/custom/campuschampions/src/Plugin/CarnegieCodesLookup.php
@@ -14,6 +14,40 @@ namespace Drupal\campuschampions\Plugin;
 class CarnegieCodesLookup {
 
   /**
+   * A list of Estab­lished Program to Stim­u­late Com­pet­i­tive Research (EPSCoR) states
+   *
+   * @var array<int,string>
+   */
+  const EPSCOR_STATES = array(
+    'AK', 'AL', 'AR', 'DE', 'GU', 'HI', 'ID',
+    'KS', 'KY', 'LA', 'ME', 'MS', 'MT', 'ND',
+    'NE', 'NH', 'NM', 'NV', 'OK', 'PR', 'RI',
+    'SC', 'SD', 'VI', 'VT', 'WV', 'WY',
+  );
+
+  /**
+   * A list of state per region
+   *
+   * @var array<string,int>
+   */
+  const REGIONS = array(
+    'AK' => 1, 'AL' => 5, 'AR' => 4, 'AZ' => 2,
+    'CA' => 2, 'CO' => 8, 'CT' => 7, 'DC' => 6,
+    'DE' => 6, 'FL' => 5, 'GA' => 5, 'HI' => 2,
+    'IA' => 3, 'ID' => 1, 'IL' => 3, 'IN' => 6,
+    'KS' => 4, 'KY' => 6, 'LA' => 4, 'MA' => 7,
+    'MD' => 6, 'ME' => 7, 'MI' => 6, 'MN' => 3,
+    'MO' => 4, 'MS' => 5, 'MT' => 1, 'NC' => 5,
+    'ND' => 3, 'NE' => 4, 'NH' => 7, 'NJ' => 6,
+    'NM' => 8, 'NV' => 2, 'NY' => 7, 'OH' => 6,
+    'OK' => 4, 'OR' => 1, 'PA' => 6, 'PR' => 5,
+    'RI' => 7, 'SC' => 5, 'SD' => 3, 'TN' => 5,
+    'TX' => 4, 'UT' => 8, 'VA' => 6, 'VI' => 5,
+    'VT' => 7, 'WA' => 1, 'WI' => 3, 'WV' => 6,
+    'WY' => 8, 'GU' => 2,
+  );
+
+  /**
    * Select db.
    *
    * @var \Drupal\Core\Database\Query\SelectInterface
@@ -40,4 +74,70 @@ class CarnegieCodesLookup {
     return $result;
   }
 
+  /**
+   * Is the given state an EPSCoR state?
+   *
+   * @param string $stabbr
+   * @return bool
+   */
+  public static function isEpscor($stabbr) {
+    return in_array($stabbr, self::EPSCOR_STATES);
+  }
+
+  /**
+   * Calculate the type ID
+   *
+   * type_id = MSI + 10 * EPS_lookup + 100 * non-academy
+   *
+   * @param int $msi
+   * @param string $stabbr
+   * @param string|int $cc
+   * @return int
+   */
+  public static function typeId($msi, $stabbr, $cc) {
+    $eps_lookup = 0;
+    if (self::isEpscor($stabbr)) {
+      $eps_lookup = 1;
+    }
+
+    $nonacademy = 0;
+    if (is_numeric($cc)) {
+      $nonacademy = $cc > 9999 ? 0 : 1;
+    }
+
+    return ($msi + 10) * $eps_lookup + (100 * $nonacademy);
+  }
+
+  /**
+   * Get the type in human readable text
+   *
+   * @param int $type_id
+   * @return string
+   */
+  public static function type($type_id) {
+    switch ($type_id) {
+      case 110:
+      case 100: $type = 'Other Not-For-Profit Organization'; break;
+      case 11:  $type = 'MSI in EPSCoR jurisdiction';        break;
+      case 10:  $type = 'EPSCoR';                            break;
+      case 1:   $type = 'Minority Serving Institution';      break;
+      case 0:
+      default:  $type = 'Academic Institution';
+    }
+
+    return $type;
+  }
+
+  /**
+   * Get the region ID by state
+   *
+   * @param string $stabbr
+   * @return int
+   */
+  public static function region($stabbr) {
+    if (isset(self::REGIONS[$stabbr])) {
+      return self::REGIONS[$stabbr];
+    }
+    return 0;
+  }
 }

--- a/web/modules/custom/campuschampions/templates/campuschampions-block.html.twig
+++ b/web/modules/custom/campuschampions/templates/campuschampions-block.html.twig
@@ -13,7 +13,7 @@
                     <div class="cc-category">
                         Champions Nationionwide
                     </div>
-                    <div id="cc-nationwide" class="cc-num odometer">
+                    <div id="cc-nationwide" class="cc-num odometer" data-value="{{ data.nationwide }}">
                         0
                     </div>
                 </div>
@@ -21,7 +21,7 @@
                     <div class="cc-category">
                         Institutions Represented
                     </div>
-                    <div id="cc-institutions" class="cc-num odometer">
+                    <div id="cc-institutions" class="cc-num odometer" data-value="{{ data.institutions }}">
                         0
                     </div>
                 </div>
@@ -29,7 +29,7 @@
                     <div class="cc-category">
                         Institutions in EPSCoR States
                     </div>
-                    <div id="cc-epscor" class="cc-num odometer">
+                    <div id="cc-epscor" class="cc-num odometer" data-value="{{ data.epscor }}">
                         0
                     </div>
                 </div>
@@ -37,7 +37,7 @@
                     <div class="cc-category">
                         Minority Serving Institutions
                     </div>
-                    <div id="cc-msi" class="cc-num odometer">
+                    <div id="cc-msi" class="cc-num odometer" data-value="{{ data.msi }}">
                         0
                     </div>
                 </div>


### PR DESCRIPTION
## Describe context / purpose for this PR

This adds a Drush command to generate a JSON file of stats used on the Campus Champions front page. The block that displays this data is changed from hard-coded values to, instead, check for the existence of the JSON stats file and, if it exists, pulls data from it. Some hard-coded values are left as fallback values (find a better solution for setting fallback values? remove them and don't worry about?). Command should be set up as a CRON job to keep stats fresh.

## Issue link

https://cyberteamportal.atlassian.net/browse/D8-1587

## Checklist for PR author
- [X] I have checked that the PR is ready to be merged
- [X] I have reviewed the DIFF and checked that the changes are as expected
- [X] I have assigned myself or someone else to review the PR
