### PR TITLE
D8 1851 Campus Champions Export

### DIFF
--- a/web/sites/default/config/default/user.role.campuschampionsadmin.yml
+++ b/web/sites/default/config/default/user.role.campuschampionsadmin.yml
@@ -4,10 +4,12 @@ status: true
 dependencies:
   module:
     - actions_permissions
+    - field_permissions
 id: campuschampionsadmin
 label: CampusChampionsAdmin
 weight: 2
 is_admin: null
 permissions:
+  - 'create field_carnegie_code'
   - 'execute campuschampions_approve_cc_action all'
   - 'execute campuschampions_approve_cc_decline all'

--- a/web/sites/default/config/default/views.view.campus_champions_user_export.yml
+++ b/web/sites/default/config/default/views.view.campus_champions_user_export.yml
@@ -15,8 +15,6 @@ dependencies:
     - taxonomy
     - user
     - views_data_export
-    - webform
-    - webform_views
 id: campus_champions_user_export
 label: 'Campus Champions - User export'
 module: views
@@ -210,59 +208,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        webform_submission_value:
-          id: webform_submission_value
-          table: webform_submission_field_join_campus_champions_champion_user_type
-          field: webform_submission_value
-          relationship: webform_submission
-          group_type: group
-          admin_label: ''
-          plugin_id: webform_submission_field
-          label: Designation
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          webform_element_format: value
-          webform_multiple_value: true
-          webform_multiple_delta: 0
-          webform_check_access: 1
         field_carnegie_code_site:
           id: field_carnegie_code_site
           table: user__field_carnegie_code
@@ -1068,17 +1013,7 @@ display:
           replica: false
           query_tags: {  }
           contextual_filters_or: false
-      relationships:
-        webform_submission:
-          id: webform_submission
-          table: users_field_data
-          field: webform_submission
-          relationship: none
-          group_type: group
-          admin_label: 'Webform submission'
-          entity_type: user
-          plugin_id: standard
-          required: false
+      relationships: {  }
       group_by: true
       header: {  }
       footer: {  }


### PR DESCRIPTION
## Describe context / purpose for this PR

Remove webform relationship and give CampusChampionAdmin role access to user carnegie code field. The webform relationship was causing several records to not be included due to the permissions settings for the CampusChampionAdmin role required to access the `/cc-users/export` page. It should be noted the alternative is to keep the relationship but adjust the permissions on the role by giving access to view all webform submission data (probably not desired but does also resolve this issue).

## Issue link

https://cyberteamportal.atlassian.net/browse/D8-1851

## Checklist for PR author
- [X] I have checked that the PR is ready to be merged
- [X] I have reviewed the DIFF and checked that the changes are as expected
- [X] I have assigned myself or someone else to review the PR
