### PR TITLE
Cypress slack notifications, and a couple cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,6 +16,77 @@ permissions:
   actions: read
   pull-requests: write
 jobs:
+  # test_slack_notification:
+  #   name: Actions to run on launch
+  #   # needs: [asp]
+  #   runs-on: ubuntu-latest
+  #   steps:
+
+  #     - name: create a dummy3 file to test MeilCli slack notification
+  #       run: |
+  #         mkdir -p dummy_folder
+  #         echo "dummy3 file" > dummy_folder/dummy3.txt
+
+  #     # - name: Slack Notification Fail with rtCamp to behat-git-notifications channel
+  #     #   uses: rtCamp/action-slack-notify@v2
+  #     #   env:
+  #     #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #     #     SLACK_MESSAGE: 'test notification to behat-git-notifications channel'
+  #     #     SLACK_TITLE: "test notification to behat channel"
+  #     #     SLACK_CHANNEL: behat-git-notifications
+
+  #     - name: Slack Notification Fail with rtCamp to cypress-git-notifications channel
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_MESSAGE: 'test notification to behat-git-notifications channel'
+  #         SLACK_TITLE: "test notification to cypress channel"
+  #         SLACK_CHANNEL: cypress-git-notifications
+
+
+  #     - name: Slack Notification with MeilCli/slack-upload-file@v2 to behat channel
+  #       uses: MeilCli/slack-upload-file@v2
+  #       with:
+      #     slack_token: ${{ secrets.SLACK_TOKEN }}
+      #     channels: behat-git-notifications
+      #     file_path: 'dummy_folder/*'
+      #     file_type: 'text'
+      #     initial_comment: 'Files found in dummy_folder/*'
+
+      # # - name: Slack Notification with MeilCli/slack-upload-file@v2 to behat channel
+      # #   uses: MeilCli/slack-upload-file@v2
+      # #   with:
+      #     slack_token: ${{ secrets.SLACK_TOKEN }}
+      #     channels: behat-git-notifications
+      #     file_path: 'tests/behat/screenshots/*.png'
+      #     file_type: 'images'
+      #     initial_comment: 'Files found in tests/behat/screenshots, for help in diagnosing behat failures'
+
+
+      # - name: Slack Notification with MeilCli/slack-upload-file@v2 to cypress channel
+      #   uses: MeilCli/slack-upload-file@v2
+      #   with:
+      #     slack_token: ${{ secrets.SLACK_TOKEN }}
+      #     channels: behat-git-notifications
+      #     file_path: 'tests/cypress/cypress/screenshots/*'
+      #     file_type: 'images'
+      #     initial_comment: 'Files found in tests/cypress/cypress/screenshots/*, for help in diagnosing cypress failures'
+
+
+      # - name: Slack Notification Fail with MeilCli
+      #   uses: MeilCli/slack-upload-file@v3
+      #   with:
+      #     slack_token: ${{ secrets.SLACK_TOKEN }}
+      #     channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
+      #     # channel_id: cypress-git-notifications
+      #     content: 'file content'
+      #     # file_type: 'text'
+      #     file_name: 'dummy3.txt'
+      #     title: 'dummy3.txt file'
+      #     initial_comment: 'post by MeilCli v3 slack-upload-file'
+      #     # thread_ts: 'option'
+
+
   asp:
     uses: necyberteam/reusable_actions/.github/workflows/cypress.yml@main
     if: contains(github.event.inputs.sites, 'asp')
@@ -38,7 +109,7 @@ jobs:
       - name: Comment on pull request
         if: "${{ env.prnum  != '' }}"
         run: |
-          gh pr comment $prnum -R $REPO --body "🤖 -=-=-=- Test was Successful -=-=-=- 🤖"
+          gh pr comment $prnum -R $REPO --body "🤖 -=-=-=- Cypress Test was Successful -=-=-=- 🤖"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prnum: ${{ github.event.inputs.prnum }}
@@ -48,8 +119,9 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: 'success :rocket:'
-          SLACK_TITLE: "Github action: test success"
+          SLACK_TITLE: "Github action: cypress test success"
           SLACK_CHANNEL: behat-git-notifications
+
   fail:
     name: Actions to run on fail
     needs: [asp]
@@ -64,10 +136,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prnum: ${{ github.event.inputs.prnum }}
           REPO: "${{ github.server_url }}/${{ github.repository }}"
-      - name: Slack Notification Fail
+      - name: Slack Notification Fail with rtCamp
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: ':octagonal_sign: behat tests failed :octagonal_sign:'
+          SLACK_MESSAGE: ':octagonal_sign: cypress tests failed :octagonal_sign:'
           SLACK_TITLE: "Github action: cypress failure"
           SLACK_CHANNEL: behat-git-notifications

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,78 +16,9 @@ permissions:
   actions: read
   pull-requests: write
 jobs:
-  # test_slack_notification:
-  #   name: Actions to run on launch
-  #   # needs: [asp]
-  #   runs-on: ubuntu-latest
-  #   steps:
-
-  #     - name: create a dummy3 file to test MeilCli slack notification
-  #       run: |
-  #         mkdir -p dummy_folder
-  #         echo "dummy3 file" > dummy_folder/dummy3.txt
-
-  #     # - name: Slack Notification Fail with rtCamp to behat-git-notifications channel
-  #     #   uses: rtCamp/action-slack-notify@v2
-  #     #   env:
-  #     #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #     #     SLACK_MESSAGE: 'test notification to behat-git-notifications channel'
-  #     #     SLACK_TITLE: "test notification to behat channel"
-  #     #     SLACK_CHANNEL: behat-git-notifications
-
-  #     - name: Slack Notification Fail with rtCamp to cypress-git-notifications channel
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_MESSAGE: 'test notification to behat-git-notifications channel'
-  #         SLACK_TITLE: "test notification to cypress channel"
-  #         SLACK_CHANNEL: cypress-git-notifications
-
-
-  #     - name: Slack Notification with MeilCli/slack-upload-file@v2 to behat channel
-  #       uses: MeilCli/slack-upload-file@v2
-  #       with:
-      #     slack_token: ${{ secrets.SLACK_TOKEN }}
-      #     channels: behat-git-notifications
-      #     file_path: 'dummy_folder/*'
-      #     file_type: 'text'
-      #     initial_comment: 'Files found in dummy_folder/*'
-
-      # # - name: Slack Notification with MeilCli/slack-upload-file@v2 to behat channel
-      # #   uses: MeilCli/slack-upload-file@v2
-      # #   with:
-      #     slack_token: ${{ secrets.SLACK_TOKEN }}
-      #     channels: behat-git-notifications
-      #     file_path: 'tests/behat/screenshots/*.png'
-      #     file_type: 'images'
-      #     initial_comment: 'Files found in tests/behat/screenshots, for help in diagnosing behat failures'
-
-
-      # - name: Slack Notification with MeilCli/slack-upload-file@v2 to cypress channel
-      #   uses: MeilCli/slack-upload-file@v2
-      #   with:
-      #     slack_token: ${{ secrets.SLACK_TOKEN }}
-      #     channels: behat-git-notifications
-      #     file_path: 'tests/cypress/cypress/screenshots/*'
-      #     file_type: 'images'
-      #     initial_comment: 'Files found in tests/cypress/cypress/screenshots/*, for help in diagnosing cypress failures'
-
-
-      # - name: Slack Notification Fail with MeilCli
-      #   uses: MeilCli/slack-upload-file@v3
-      #   with:
-      #     slack_token: ${{ secrets.SLACK_TOKEN }}
-      #     channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
-      #     # channel_id: cypress-git-notifications
-      #     content: 'file content'
-      #     # file_type: 'text'
-      #     file_name: 'dummy3.txt'
-      #     title: 'dummy3.txt file'
-      #     initial_comment: 'post by MeilCli v3 slack-upload-file'
-      #     # thread_ts: 'option'
-
 
   asp:
+    name: Run cypress tests in 'accessmatch' directory
     uses: necyberteam/reusable_actions/.github/workflows/cypress.yml@main
     if: contains(github.event.inputs.sites, 'asp')
     secrets:
@@ -114,13 +45,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prnum: ${{ github.event.inputs.prnum }}
           REPO: "${{ github.server_url }}/${{ github.repository }}"
+      - name: create notification file
+        run: |
+          echo "🤖 -=-=-=- Cypress Test Succeeded -=-=-=- 🤖" > Cypress_Tests_Succeeded.txt
       - name: Slack Notification Success
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: 'success :rocket:'
-          SLACK_TITLE: "Github action: cypress test success"
-          SLACK_CHANNEL: behat-git-notifications
+        uses: MeilCli/slack-upload-file@v2
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          channels: cypress-git-notifications
+          file_path: 'Cypress_Tests_Succeeded.txt'
+          file_type: 'text'
+          initial_comment: '🤖 -=-=-=- Cypress Test Succeeded -=-=-=- 🤖'
 
   fail:
     name: Actions to run on fail
@@ -136,10 +71,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prnum: ${{ github.event.inputs.prnum }}
           REPO: "${{ github.server_url }}/${{ github.repository }}"
-      - name: Slack Notification Fail with rtCamp
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: ':octagonal_sign: cypress tests failed :octagonal_sign:'
-          SLACK_TITLE: "Github action: cypress failure"
-          SLACK_CHANNEL: behat-git-notifications
+      - name: create notification file
+        run: |
+          echo "🤖 -=-=-=- Cypress Test Failed -=-=-=- 🤖" > Cypress_Tests_Failed.txt
+      - name: Slack Notification Fail
+        uses: MeilCli/slack-upload-file@v2
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          channels: cypress-git-notifications
+          file_path: 'Cypress_Tests_Failed.txt'
+          file_type: 'text'
+          initial_comment: '🤖 -=-=-=- Cypress Test Failed -=-=-=- 🤖'

--- a/tests/cypress/cypress/e2e/accessmatch/0-breaking-test.js
+++ b/tests/cypress/cypress/e2e/accessmatch/0-breaking-test.js
@@ -1,0 +1,10 @@
+describe('breaking test to trigger slack notification', () => {
+  it('checks', () => {
+    cy.task("log", "breaking test to trigger slack notification");
+    var url = 'https://example.cypress.io';
+    cy.task("log", "trying to reach '" + url + "'");
+    cy.visit(url);
+    cy.task("log", "looking for text that doesn't exist, should break");
+    cy.contains('this-will-break');
+  })
+})

--- a/tests/cypress/cypress/e2e/accessmatch/ccep.cy.js
+++ b/tests/cypress/cypress/e2e/accessmatch/ccep.cy.js
@@ -1,0 +1,12 @@
+describe('Test ASP /ccep page', () => {
+  it('tests the page', () => {
+    cy.visit('/ccep');
+    cy.get(':nth-child(2) > .col > .mt-3 > .btn')
+      .contains('Apply now')
+      .click();
+    cy.origin('https://docs.google.com', () => {
+      cy.contains('ACCESS CSSN Community Engagement Program (CCEP) Travel Award Request');
+    });
+    cy.task("log", "ccep test complete");
+  })
+})


### PR DESCRIPTION
## Describe context / purpose for this PR
I burned the midnight oil to find a way to get notifications to cypress-tests-notifications slack channel.  
I was not able to use rtCamp/action-slack-notify@v2 -- it would silently not post to the channel.  
But I was able to use  MeilCli/slack-upload-file@v2 -- it does post to the channel.  The reusable action now uploads screenshots, and the encompassing action that runs cypress tests posts a pass/fail file to the channel.  It's a little klunky, but it works.


## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1866

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
