### PR TITLE
Affinity Group Email view website button d8-1974

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "access/operations_cider": "dev-main",
     "acquia/blt": "^13.7",
     "acquia/blt-behat": "^1.3",
-    "amp/access": "dev-d8-1974",
+    "amp/access": "3.0.x-dev",
     "composer/installers": "^1.2",
     "cweagans/composer-patches": "^1.6",
     "drupal/access_by_ref": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "access/operations_cider": "dev-main",
     "acquia/blt": "^13.7",
     "acquia/blt-behat": "^1.3",
-    "amp/access": "3.0.x-dev",
+    "amp/access": "dev-d8-1974",
     "composer/installers": "^1.2",
     "cweagans/composer-patches": "^1.6",
     "drupal/access_by_ref": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58a40cd4ac0d6bc3507020d09839e793",
+    "content-hash": "d66cdf2a7d362c5cd2efbb2d9a4f7a63",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -291,17 +291,16 @@
         },
         {
             "name": "amp/access",
-            "version": "3.0.x-dev",
+            "version": "dev-d8-1974",
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/access.git",
-                "reference": "0d51a8cecfc9943c8a619fd31218ef65c913d26f"
+                "reference": "6283f3f210cdda70feb6868836e09a4a5bf86ba3"
             },
             "require": {
                 "gioni06/gpt3-tokenizer": "^1.2",
                 "openai-php/client": "^0.4.1"
             },
-            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "GPL-2.0+"
@@ -317,7 +316,7 @@
                 "issues": "https://github.com/necyberteam/access/issues",
                 "source": "https://github.com/necyberteam/access"
             },
-            "time": "2024-01-19T19:33:26+00:00"
+            "time": "2024-01-23T00:03:07+00:00"
         },
         {
             "name": "arthurkushman/query-path",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d66cdf2a7d362c5cd2efbb2d9a4f7a63",
+    "content-hash": "58a40cd4ac0d6bc3507020d09839e793",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -291,16 +291,17 @@
         },
         {
             "name": "amp/access",
-            "version": "dev-d8-1974",
+            "version": "3.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/access.git",
-                "reference": "51adc8e90de6eddb4f8c722819073e40a154b8da"
+                "reference": "04faf86846a92e5a97d4c155465e597ae72305e2"
             },
             "require": {
                 "gioni06/gpt3-tokenizer": "^1.2",
                 "openai-php/client": "^0.4.1"
             },
+            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "GPL-2.0+"
@@ -316,7 +317,7 @@
                 "issues": "https://github.com/necyberteam/access/issues",
                 "source": "https://github.com/necyberteam/access"
             },
-            "time": "2024-01-23T17:12:44+00:00"
+            "time": "2024-01-26T22:41:03+00:00"
         },
         {
             "name": "arthurkushman/query-path",
@@ -11438,7 +11439,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/campus-champions-theme.git",
-                "reference": "144634d4e7459482e4803c32a9fc5d2bac3a7759"
+                "reference": "c8c50fbad226755a9ad77576963cd6cdd0b489c8"
             },
             "default-branch": true,
             "type": "drupal-theme",
@@ -11456,7 +11457,7 @@
                 "issues": "https://github.com/necyberteam/campus-champions-theme/issues",
                 "source": "https://github.com/necyberteam/campus-champions-theme"
             },
-            "time": "2024-01-05T16:37:53+00:00"
+            "time": "2024-01-26T22:11:22+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -295,7 +295,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/access.git",
-                "reference": "6283f3f210cdda70feb6868836e09a4a5bf86ba3"
+                "reference": "51adc8e90de6eddb4f8c722819073e40a154b8da"
             },
             "require": {
                 "gioni06/gpt3-tokenizer": "^1.2",
@@ -316,7 +316,7 @@
                 "issues": "https://github.com/necyberteam/access/issues",
                 "source": "https://github.com/necyberteam/access"
             },
-            "time": "2024-01-23T00:03:07+00:00"
+            "time": "2024-01-23T17:12:44+00:00"
         },
         {
             "name": "arthurkushman/query-path",


### PR DESCRIPTION
## Describe context / purpose for this PR
In Affinity Group Emails for constant contact, need to remove the View Website button on the emails that are 
generated from the Send Emails button that a group coordinator can use to email the Affinity Group members. 
We need the button on the emails generated by the other functions.

I touched code that is used by all of the functions that use Constant Contact emailing, resulting in having to test
them all, so I decided to move some related code out of the .module file. 
The 7 code paths are:
* Access Digest (Create from Constant Contact Token page)
* New event broadcast to affinity group x 2
* New announcement broadcast to affinity group x2
* Email message sent from "Email Affinity Group" button  x2
All but the first have separate code paths for Affinity Groups that are of type Community vs ACCESS_RP, since the email wrapper differs.

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1974

## Any other related PRs?
https://github.com/necyberteam/access/pull/188

## Link to MultiDev instance
http://md-1974-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
