### PR TITLE
Small changes on Announcements and events pages  d8-1966

### DIFF
--- a/tests/behat/features/templates/tags/tags-auth.feature
+++ b/tests/behat/features/templates/tags/tags-auth.feature
@@ -14,7 +14,7 @@ Feature: This test is as an authenticated user.
     And I should see "Search"
     And I should see "login"
     And I should see "osg"
-    And I should see "ACCESS RPs"
+    And I should see "ACCESS Resources"
     And I should see "xsede"
 
   Scenario: Tags pages shows "Request Tag" for authenticated user

--- a/tests/behat/features/templates/tags/tags-request-auth.feature
+++ b/tests/behat/features/templates/tags/tags-request-auth.feature
@@ -15,7 +15,7 @@ An email is sent to the NECT mailing list upon submission.
     And I should see "Tag Request Name"
     And I should see "Suggested Parent Tag"
     When I fill in "Tag Request Name" with "TEST"
-    # this specifies ACCESS RPs as the parent
+    # this specifies ACCESS Resources as the parent
     When I select "684" from "Suggested Parent Tag"
     And I wait 2 seconds
     When I press "Submit"

--- a/tests/behat/features/templates/tags/tags-unauth.feature
+++ b/tests/behat/features/templates/tags/tags-unauth.feature
@@ -13,7 +13,7 @@ Feature: Tests for the Tags page with unauthenticated user.  Verify "Request Tag
       And I should see "Search"
       And I should see "login"
       And I should see "osg"
-      And I should see "ACCESS RPs"
+      And I should see "ACCESS Resources"
       And I should see "xsede"
 
     Scenario: Tags pages does not show "Request Tag" when logged out

--- a/web/sites/default/config/default/views.view.access_news.yml
+++ b/web/sites/default/config/default/views.view.access_news.yml
@@ -1193,7 +1193,22 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<p class="font-bold">No announcements.</p>'
+            format: basic_html
+          tokenize: false
       defaults:
+        empty: false
         css_class: false
         group_by: false
         fields: false

--- a/web/sites/default/config/default/views.view.recurring_events_event_instances.yml
+++ b/web/sites/default/config/default/views.view.recurring_events_event_instances.yml
@@ -830,7 +830,7 @@ display:
       exposed_form:
         type: basic
         options:
-          submit_button: Apply
+          submit_button: Filter
           reset_button: false
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'


### PR DESCRIPTION

## Describe context / purpose for this PR
Events pages - change text on  Apply button to Filter
Announcenments page text for neo results.
Headings on filter areas on 3 pages.
Content changes needed (2 new blocks placed via  edit page layout)

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1966

## Any other related PRs?

## Link to MultiDev instance

http://md-1966-accessmatch.pantheonsite.io

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
