### PR TITLE
Change 'no results' text on past events page md-2012b (d8-2012)

### DIFF
--- a/web/sites/default/config/default/views.view.recurring_events_event_instances.yml
+++ b/web/sites/default/config/default/views.view.recurring_events_event_instances.yml
@@ -3248,6 +3248,20 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'No events or trainings match these criteria.'
+            format: basic_html
+          tokenize: false
       filters:
         status:
           id: status
@@ -3590,6 +3604,7 @@ display:
           relationship: none
           view_mode: list
       defaults:
+        empty: false
         title: false
         style: false
         row: false


### PR DESCRIPTION
The small change in here is also in the newer
https://github.com/necyberteam/cyberteam_drupal/pull/1119

## Describe context / purpose for this PR
Change 'no results' text on past events page
## Issue link
https://cyberteamportal.atlassian.net/browse/D8-2012
## Any other related PRs?

## Link to MultiDev instance
http://md-2012b-accessmatch.pantheonsite.io/

http://md-2012b-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
