### PR TITLE
Fix pager on Events page  md-2031 (also contains md-2012b)

### DIFF
--- a/tests/behat/features/templates/footer/regions_connect_ci.feature
+++ b/tests/behat/features/templates/footer/regions_connect_ci.feature
@@ -23,8 +23,8 @@ Users have the option to toggle between card and list display formats.
     When I follow "CAREERS Cyberteam"
     Then I should be on "https://careers-ct.cyberinfrastructure.org"
     When I go to "regions"
-    When I follow "ArcGIS Users"
-    Then I should be on "https://campuschampions.cyberinfrastructure.org/affinity-groups/arcgis-users"
+    When I follow "Ask.CI Moderators"
+    Then I should be on "/affinity-groups/askci-moderators"
 
 
   Scenario: User is on the Connect.CI Page
@@ -40,7 +40,7 @@ Users have the option to toggle between card and list display formats.
     When I follow "Card View"
     Then I should be on "/regions"
     When I follow "CAREERS Cyberteam"
-    Then I should be on "https://careers-ct.cyberinfrastructure.org/?_gl=1*nuhgh5*_ga*MTM3NDk2NzcyMC4xNjYzMDMzNjc3*_ga_CNLGPXPT91*MTY3NTg5NTgyMi44Ny4xLjE2NzU4OTU5MzkuMC4wLjA."
+    Then I should be on "https://careers-ct.cyberinfrastructure.org/"
     When I go to "regions"
-    When I follow "ArcGIS Users"
-    Then I should be on "https://campuschampions.cyberinfrastructure.org/affinity-groups/arcgis-users?_gl=1*1ddouy5*_ga*MTM3NDk2NzcyMC4xNjYzMDMzNjc3*_ga_CNLGPXPT91*MTY3NTg5NTgyMi44Ny4xLjE2NzU4OTU5OTUuMC4wLjA."
+    When I follow "Ask.CI Moderators"
+    Then I should be on "/affinity-groups/askci-moderators"

--- a/tests/cypress/cypress/e2e/accessmatch/webforms/auth-submit-issue.cy.js
+++ b/tests/cypress/cypress/e2e/accessmatch/webforms/auth-submit-issue.cy.js
@@ -20,7 +20,7 @@ describe('Authenticated user fills out the enter ticket form', () => {
     cy.get('[name="details"]').type('TEST');
     // select a couple tags
     cy.get('#edit-tags3-733').check();
-    cy.get('#edit-tags3-734').check();
+    cy.get('#edit-tags3-690').check();
     cy.contains('Submit').click();
     cy.contains('Thank you! Your ticket has been submitted! We\'ll be in touch soon.');
   });

--- a/web/sites/default/config/default/views.view.recurring_events_event_instances.yml
+++ b/web/sites/default/config/default/views.view.recurring_events_event_instances.yml
@@ -2232,8 +2232,8 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: 'Next ›'
-            previous: '‹ Previous'
+            next: '>>'
+            previous: '<<'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -2779,6 +2779,9 @@ display:
         title: false
         css_class: false
         pager: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
         link_display: false
         link_url: false
         style: false
@@ -2789,6 +2792,9 @@ display:
         filter_groups: false
       css_class: ''
       display_description: ''
+      use_more: false
+      use_more_always: false
+      use_more_text: 'All Events'
       link_display: '0'
       link_url: /events
       exposed_block: true
@@ -3248,6 +3254,20 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'No events or trainings match these criteria.'
+            format: basic_html
+          tokenize: false
       filters:
         status:
           id: status
@@ -3590,6 +3610,7 @@ display:
           relationship: none
           view_mode: list
       defaults:
+        empty: false
         title: false
         style: false
         row: false

--- a/web/sites/default/config/default/views.view.recurring_events_event_series.yml
+++ b/web/sites/default/config/default/views.view.recurring_events_event_series.yml
@@ -2010,7 +2010,7 @@ display:
           offset: 0
           items_per_page: 10
           total_pages: null
-          id: 0
+          id: 1
           tags:
             next: ››
             previous: ‹‹


### PR DESCRIPTION
## Describe context / purpose for this PR
Change id number of pager on event series pager so it won't conflict
with event instance pager when placed on the same page.

Note the simple fix for md-2012 is in the same file so I just left it there.

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-2031

## Any other related PRs?

## Link to MultiDev instance

http://md-2031-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
