### PR TITLE
Remove repeated affinity group lines on User Profile D8-1752

### DIFF
--- a/web/sites/default/config/default/views.view.affinity_group.yml
+++ b/web/sites/default/config/default/views.view.affinity_group.yml
@@ -1824,7 +1824,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -1858,7 +1857,6 @@ display:
           title: ''
           default_argument_type: current_user
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -2074,7 +2072,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -2095,6 +2092,7 @@ display:
         pager: false
         link_display: false
         link_url: false
+        group_by: false
         relationships: false
         fields: false
         arguments: false
@@ -2131,6 +2129,7 @@ display:
           entity_field: uid
           plugin_id: standard
           required: false
+      group_by: true
       display_description: ''
       link_display: custom_url
       link_url: '/user/{{ arguments.uid }}'
@@ -2308,7 +2307,6 @@ display:
           default_argument_options:
             index: 0
             use_alias: false
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -2795,7 +2793,6 @@ display:
           default_argument_options:
             index: 0
             use_alias: false
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -3353,7 +3350,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -3858,7 +3854,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -4877,7 +4872,6 @@ display:
           title: '{{ arguments.nid }} '
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -6274,7 +6268,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -7610,7 +7603,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true


### PR DESCRIPTION
## Describe context / purpose for this PR
Remove repeated affinity group lines on User Profile (non-access domains) D8-1752

Note that mutiple instances of the default_argument_skip_url settings are removed from the yml, and that has nothing to do with fixing this problem. That is what the manual configuration export of the affinity group yml produced.   Apparently that setting has been removed from Drupal: https://www.drupal.org/node/3382316

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1752


## Any other related PRs?

## Link to MultiDev instance

http://md-1752-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
