### PR TITLE
fix(rp-docs): grant resource_docs format use to documentation manager

### DIFF
--- a/web/sites/default/config/default/user.role.rp_documentation_manager.yml
+++ b/web/sites/default/config/default/user.role.rp_documentation_manager.yml
@@ -2,6 +2,8 @@ uuid: 395f64f1-bafc-4aec-a0bb-13d0f94e89fd
 langcode: en
 status: true
 dependencies:
+  config:
+    - filter.format.resource_docs
   module:
     - file
     - node
@@ -18,3 +20,4 @@ permissions:
   - 'edit any access_active_resources_from_cid content'
   - 'edit any resource_group content'
   - 'edit own resource_group content'
+  - 'use text format resource_docs'


### PR DESCRIPTION
Commit 48244747c restricted the nine RP-doc fields to the new resource_docs text format but never granted permission to use it. The fields previously used basic_html, which editors had via the authenticated role, so editing worked; after the switch every non-admin was locked out with "insufficient permissions to edit." Grant 'use text format resource_docs' to rp_documentation_manager, the only role that edits these forms.

## Describe context / purpose for this PR

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
