### PR TITLE
fix(turnstile): stop sending remoteip to siteverify

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -314,10 +314,14 @@ function _serve_turnstile_challenge(string $return_url): void {
     $ch = curl_init('https://challenges.cloudflare.com/turnstile/v0/siteverify');
     curl_setopt_array($ch, [
       CURLOPT_POST => true,
+      // Do not send 'remoteip': Cloudflare validates it against the IP that
+      // solved the widget, and behind Pantheon's load balancer the client IP
+      // we resolve doesn't reliably match Cloudflare's edge view, which makes
+      // siteverify return success=false and loops the user back to the
+      // challenge. The token alone is sufficient proof of a valid solve.
       CURLOPT_POSTFIELDS => http_build_query([
         'secret' => $secret_key,
         'response' => $token,
-        'remoteip' => _get_real_client_ip(),
       ]),
       CURLOPT_RETURNTRANSFER => true,
       CURLOPT_TIMEOUT => 10,
@@ -473,10 +477,14 @@ if ($enable_turnstile && strpos($_SERVER['REQUEST_URI'], '/turnstile-verify') ==
     $ch = curl_init('https://challenges.cloudflare.com/turnstile/v0/siteverify');
     curl_setopt_array($ch, [
       CURLOPT_POST => true,
+      // Do not send 'remoteip': Cloudflare validates it against the IP that
+      // solved the widget, and behind Pantheon's load balancer the client IP
+      // we resolve doesn't reliably match Cloudflare's edge view, which makes
+      // siteverify return success=false and loops the user back to the
+      // challenge. The token alone is sufficient proof of a valid solve.
       CURLOPT_POSTFIELDS => http_build_query([
         'secret' => $secret_key,
         'response' => $token,
-        'remoteip' => _get_real_client_ip(),
       ]),
       CURLOPT_RETURNTRANSFER => true,
       CURLOPT_TIMEOUT => 10,


### PR DESCRIPTION
Binding the cookie to the real client IP also changed the remoteip sent to Cloudflare siteverify from the Pantheon LB IP to the real client IP. Cloudflare validates remoteip against the IP that solved the widget, and behind the load balancer our resolved IP doesn't reliably match Cloudflare's edge view, so siteverify returned success=false and looped solved users back to the challenge. Diagnostic logging confirmed valid tokens hitting the failure path with no cookie set. Omit remoteip; the token alone proves the solve. Cookie binding to the client IP is retained.

## Describe context / purpose for this PR

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
