### PR TITLE
config+test(rp-docs): node-count field, field descriptions, and rp-docs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,8 @@
     "require": {
         "access/drupal_seamless_cilogon": "3.0.x-dev",
         "access/infrastructure_news": "1.0.x-dev",
-        "access/operations_cider": "main-dev",
-        "amp/access": "3.0.x-dev",
+        "access/operations_cider": "dev-d8-2772",
+        "amp/access": "dev-d8-2772",
         "composer/installers": "^2.3.0",
         "cweagans/composer-patches": "^2.0",
         "drupal/access_by_ref": "^4.0.0",
@@ -194,7 +194,7 @@
         "drupal/yaml_editor": "^1.0",
         "drupal_fork/cilogon_auth": "main-dev",
         "drush/drush": "^13.6.2",
-        "necyberteam/asp-theme": "main-dev",
+        "necyberteam/asp-theme": "dev-d8-2772",
         "necyberteam/campus-champions-theme": "main-dev",
         "necyberteam/webform_submission_search_api": "main-dev",
         "npm-asset/select2": "^4.0",
@@ -205,7 +205,7 @@
         "swagger-api/swagger-ui": "^3.52"
     },
     "require-dev": {
-        "amp/amp_dev": "main-dev",
+        "amp/amp_dev": "dev-d8-2772",
         "doctrine/instantiator": "~2.0.0",
         "drupal/core-dev": "^10.6.1",
         "drupal/devel": "^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "210989a5c68be40a1cf1bdfe7a175a47",
+    "content-hash": "11b4cda7c2ca720792512ec737431f04",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -64,17 +64,16 @@
         },
         {
             "name": "access/operations_cider",
-            "version": "dev-main",
+            "version": "dev-d8-2772",
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/Operations_Drupal_Feed_Cider.git",
-                "reference": "e07b2e562f713803f7d65673b82435f9471bb6ae"
+                "reference": "c3e469c7e7917683aed16ee16e150531311c4ef2"
             },
             "require": {
                 "drupal/feeds": "^3.0@beta",
                 "drupal/feeds_ex": "^1.0@beta"
             },
-            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "Apache License, Version 2.0"
@@ -94,22 +93,21 @@
                 "issues": "https://github.com/access-ci-org/Operations_Drupal_Feed_Cider/issues",
                 "source": "https://github.com/access-ci-org/Operations_Drupal_Feed_Cider"
             },
-            "time": "2026-06-26T18:42:06+00:00"
+            "time": "2026-07-01T18:39:06+00:00"
         },
         {
             "name": "amp/access",
-            "version": "3.0.x-dev",
+            "version": "dev-d8-2772",
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/access.git",
-                "reference": "fcf58fa190350a26e598b4c4a6abc7b435e196d9"
+                "reference": "85b37e63768b3d9fe5277fb7a8b1a464e19433bd"
             },
             "require": {
                 "firebase/php-jwt": "^6.0 || ^7.0",
                 "gioni06/gpt3-tokenizer": "^1.2",
                 "openai-php/client": "^0.10"
             },
-            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "GPL-2.0+"
@@ -125,7 +123,7 @@
                 "issues": "https://github.com/necyberteam/access/issues",
                 "source": "https://github.com/necyberteam/access"
             },
-            "time": "2026-06-30T15:10:09+00:00"
+            "time": "2026-07-01T18:40:02+00:00"
         },
         {
             "name": "asm89/stack-cors",
@@ -13242,13 +13240,12 @@
         },
         {
             "name": "necyberteam/asp-theme",
-            "version": "dev-main",
+            "version": "dev-d8-2772",
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/aspTheme.git",
-                "reference": "6b093d91baf8fddf5c204a36495ac4d95f7146fd"
+                "reference": "8dead54000ea94342cbd832a3cd4025df7dfbf1a"
             },
-            "default-branch": true,
             "type": "drupal-theme",
             "license": [
                 "MIT"
@@ -13264,7 +13261,7 @@
                 "issues": "https://github.com/necyberteam/aspTheme/issues",
                 "source": "https://github.com/necyberteam/aspTheme"
             },
-            "time": "2026-06-29T15:16:12+00:00"
+            "time": "2026-07-01T15:04:31+00:00"
         },
         {
             "name": "necyberteam/campus-champions-theme",
@@ -18210,13 +18207,12 @@
     "packages-dev": [
         {
             "name": "amp/amp_dev",
-            "version": "dev-main",
+            "version": "dev-d8-2772",
             "source": {
                 "type": "git",
                 "url": "https://github.com/necyberteam/amp_dev.git",
-                "reference": "5cc7c858697c8065ff692ef90ec1e9be2c40e085"
+                "reference": "dabb7196d813f7006e3a0ba4bb3c19a6dbe590d3"
             },
-            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "GPL-2.0-or-later"
@@ -18226,7 +18222,7 @@
             "keywords": [
                 "Drupal"
             ],
-            "time": "2026-06-26T19:47:55+00:00"
+            "time": "2026-07-01T18:37:55+00:00"
         },
         {
             "name": "behat/mink",

--- a/tests/cypress/cypress/e2e/accessmatch2/rp-docs/resource-api.cy.js
+++ b/tests/cypress/cypress/e2e/accessmatch2/rp-docs/resource-api.cy.js
@@ -110,6 +110,8 @@ describe("Resource Documentation API", () => {
       // Structured queue fields stay raw and typed (GB), with a derived summary.
       const gpuStandard = body.queue_specs[0];
       expect(gpuStandard.name).to.eq("gpu-standard");
+      // node_count is the per-partition node count (field_rp_node_count).
+      expect(gpuStandard.node_count).to.eq(100);
       expect(gpuStandard.cpu_count).to.eq(64);
       expect(gpuStandard.cpu_type).to.eq("AMD EPYC 7763");
       expect(gpuStandard.gpu_count).to.eq(4);
@@ -117,14 +119,16 @@ describe("Resource Documentation API", () => {
       expect(gpuStandard.gpu_vram).to.eq(80);
       // `ram` carries node RAM (field_rp_vram, GB) despite the legacy name.
       expect(gpuStandard.ram).to.eq(256);
+      // Summary includes the node count between the GPU and CPU clauses.
       expect(gpuStandard.summary).to.eq(
-        "4 NVIDIA A100 (80 GB vRAM), 64-core AMD EPYC 7763, 256 GB RAM"
+        "4 NVIDIA A100 (80 GB vRAM), 100 nodes, 64-core AMD EPYC 7763, 256 GB RAM"
       );
       // CPU-only queue: no GPU clause in the summary.
       const cpuShared = body.queue_specs.find((q) => q.name === "cpu-shared");
       expect(cpuShared.gpu_count).to.eq(0);
+      expect(cpuShared.node_count).to.eq(200);
       expect(cpuShared.summary).to.eq(
-        "128-core Intel Xeon Platinum 8480+, 256 GB RAM"
+        "200 nodes, 128-core Intel Xeon Platinum 8480+, 256 GB RAM"
       );
 
       expect(body.datasets).to.be.an("array");

--- a/tests/cypress/cypress/e2e/accessmatch2/rp-docs/resource-page.cy.js
+++ b/tests/cypress/cypress/e2e/accessmatch2/rp-docs/resource-page.cy.js
@@ -121,17 +121,30 @@ describe("Resource Documentation Page — Alpha (full data)", () => {
   it("renders corrected GPU and Node RAM columns", () => {
     // Column relabeled away from the ambiguous "RAM" (field_rp_vram is node RAM).
     cy.get(".rp-queue-specs").contains("th", "Node RAM");
-    // GPU column no longer mislabels the count as "cores".
-    cy.get(".rp-queue-specs table").should("not.contain", "cores");
+    // Per-node column labels: CPU count reads as cores per node, GPUs per node.
+    cy.get(".rp-queue-specs").contains("th", "CPU cores / node");
+    cy.get(".rp-queue-specs").contains("th", "GPUs / node");
     // GPU cell: "<count> <type> (<vram> GB vRAM)" and Node RAM in GB.
     cy.get(".rp-queue-specs table tbody tr").contains("td", "gpu-standard")
       .parent("tr").within(() => {
         cy.contains("4 NVIDIA A100 (80 GB vRAM)");
         cy.contains("256 GB");
+        // CPU count renders as cores (per-node), not "CPUs".
+        cy.contains("64 cores");
       });
     // CPU-only queue shows a dash for GPU, never "0 …".
     cy.get(".rp-queue-specs table tbody tr").contains("td", "cpu-shared")
       .parent("tr").should("contain", "—").and("not.contain", "0 NVIDIA");
+  });
+
+  it("renders the per-partition Nodes column", () => {
+    cy.get(".rp-queue-specs").contains("th", "Nodes");
+    // gpu-standard has field_rp_node_count = 100 in the fixture.
+    cy.get(".rp-queue-specs table tbody tr").contains("td", "gpu-standard")
+      .parent("tr").should("contain", "100");
+    // cpu-shared has field_rp_node_count = 200.
+    cy.get(".rp-queue-specs table tbody tr").contains("td", "cpu-shared")
+      .parent("tr").should("contain", "200");
   });
 
   it("renders top software table", () => {

--- a/tests/cypress/cypress/e2e/accessmatch2/rp-docs/rp-account-panel.cy.js
+++ b/tests/cypress/cypress/e2e/accessmatch2/rp-docs/rp-account-panel.cy.js
@@ -55,10 +55,61 @@ describe("RP account panel", () => {
     cy.loginAs("walnut@pie.org", "Walnut");
     cy.visit(RP_PATH);
 
-    // Whether the SSR rendered a skeleton or the existing CTA, after JS runs
-    // the visible state should be the CTA (heading with "GET AN ACCOUNT").
-    // The wait is generous because JS has to fire and rewrite the DOM.
-    cy.contains("GET AN ACCOUNT ON", { timeout: 5000 }).should("be.visible");
+    // Wait for the account-status fetch to resolve, then assert the JS rewrote
+    // the panel to the CTA. Login + SSR + async render can take >15s locally,
+    // so wait on the request and give the DOM assertion a generous timeout.
+    cy.wait("@rpAccount");
+    cy.contains("GET AN ACCOUNT ON", { timeout: 20000 }).should("be.visible");
+  });
+
+  it("renders the account_setup link (not the generic allocations CTA) when the API returns one", () => {
+    cy.intercept("GET", "/api/1.0/rp-account/*", {
+      statusCode: 200,
+      body: {
+        rp_nid: 1,
+        rp_display_name: "Test Resource Alpha",
+        state: "no_rows_fresh",
+        has_account: false,
+        stale: false,
+        synced_at: 1746737000,
+        manage_url: "https://allocations.access-ci.org/",
+        account_setup: {
+          uri: "https://docs.example.edu/alpha/accounts",
+          title: "Alpha account setup",
+        },
+      },
+    }).as("rpAccount");
+
+    cy.loginAs("walnut@pie.org", "Walnut");
+    cy.visit(RP_PATH);
+
+    // Wait for the account-status fetch to resolve before asserting on the DOM
+    // the JS rewrites from its response; login + SSR + async render can take
+    // >15s locally, so also give the assertions a generous timeout.
+    cy.wait("@rpAccount");
+
+    // The no-account panel should surface the resource-specific setup link,
+    // using its title and href, rather than the generic allocations link.
+    cy.contains("GET AN ACCOUNT ON", { timeout: 20000 }).should("be.visible");
+    cy.contains("a", "Alpha account setup", { timeout: 20000 })
+      .should("be.visible")
+      .and("have.attr", "href", "https://docs.example.edu/alpha/accounts");
+  });
+
+  it("shows a neutral unavailable message after retries when the account fetch keeps failing", () => {
+    // Always fail the fetch; the JS retries a bounded number of times and then
+    // replaces the "Loading…" skeleton with a neutral message instead of
+    // spinning forever.
+    cy.intercept("GET", "/api/1.0/rp-account/*", { statusCode: 500, body: {} }).as("rpAccount");
+
+    cy.loginAs("walnut@pie.org", "Walnut");
+    cy.visit(RP_PATH);
+
+    // Wait for the first failing fetch, then allow for the retry backoff
+    // (~3s) plus login + SSR + render before the neutral message appears.
+    cy.wait("@rpAccount");
+    cy.contains("temporarily unavailable", { timeout: 25000 }).should("be.visible");
+    cy.contains("Loading account info").should("not.exist");
   });
 
   it("substitutes rp_username in the SSH placeholder", () => {

--- a/web/sites/default/config/default/core.entity_form_display.paragraph.rp_queue_spec.default.yml
+++ b/web/sites/default/config/default/core.entity_form_display.paragraph.rp_queue_spec.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.paragraph.rp_queue_spec.field_rp_gpu_count
     - field.field.paragraph.rp_queue_spec.field_rp_gpu_vram
     - field.field.paragraph.rp_queue_spec.field_rp_gpus
+    - field.field.paragraph.rp_queue_spec.field_rp_node_count
     - field.field.paragraph.rp_queue_spec.field_rp_queue_name
     - field.field.paragraph.rp_queue_spec.field_rp_queue_purpose
     - field.field.paragraph.rp_queue_spec.field_rp_ram
@@ -53,6 +54,13 @@ content:
     region: content
     settings:
       size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_rp_node_count:
+    type: number
+    weight: 2
+    region: content
+    settings:
       placeholder: ''
     third_party_settings: {  }
   field_rp_queue_name:

--- a/web/sites/default/config/default/core.entity_view_display.paragraph.rp_queue_spec.default.yml
+++ b/web/sites/default/config/default/core.entity_view_display.paragraph.rp_queue_spec.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.paragraph.rp_queue_spec.field_rp_gpu_count
     - field.field.paragraph.rp_queue_spec.field_rp_gpu_vram
     - field.field.paragraph.rp_queue_spec.field_rp_gpus
+    - field.field.paragraph.rp_queue_spec.field_rp_node_count
     - field.field.paragraph.rp_queue_spec.field_rp_queue_name
     - field.field.paragraph.rp_queue_spec.field_rp_queue_purpose
     - field.field.paragraph.rp_queue_spec.field_rp_ram
@@ -95,4 +96,5 @@ content:
     weight: 8
     region: content
 hidden:
+  field_rp_node_count: true
   search_api_excerpt: true

--- a/web/sites/default/config/default/field.field.node.access_active_resources_from_cid.field_rp_account_setup_url.yml
+++ b/web/sites/default/config/default/field.field.node.access_active_resources_from_cid.field_rp_account_setup_url.yml
@@ -12,7 +12,7 @@ field_name: field_rp_account_setup_url
 entity_type: node
 bundle: access_active_resources_from_cid
 label: 'RP Account Setup URL'
-description: 'URL where users can request or set up an account on this resource provider. Displayed as a link in the Login section of the RP documentation page. Leave blank if no separate RP account is needed (e.g., if ACCESS credentials are sufficient).'
+description: 'URL where users can request or set up an account on this resource provider. Displayed as a link in the sidebar "Get an account" call-to-action on the RP documentation page. Leave blank if no separate RP account is needed (e.g., if ACCESS credentials are sufficient).'
 required: false
 translatable: false
 default_value: {  }

--- a/web/sites/default/config/default/field.field.paragraph.rp_queue_spec.field_rp_node_count.yml
+++ b/web/sites/default/config/default/field.field.paragraph.rp_queue_spec.field_rp_node_count.yml
@@ -1,0 +1,23 @@
+uuid: bacde4b9-c39b-4bc1-8996-c4597baa03e0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_rp_node_count
+    - paragraphs.paragraphs_type.rp_queue_spec
+id: paragraph.rp_queue_spec.field_rp_node_count
+field_name: field_rp_node_count
+entity_type: paragraph
+bundle: rp_queue_spec
+label: 'Number of nodes'
+description: 'Number of nodes in this partition'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/web/sites/default/config/default/field.field.paragraph.rp_storage_filesystem.field_rp_quota_inode_amount.yml
+++ b/web/sites/default/config/default/field.field.paragraph.rp_storage_filesystem.field_rp_quota_inode_amount.yml
@@ -10,7 +10,7 @@ field_name: field_rp_quota_inode_amount
 entity_type: paragraph
 bundle: rp_storage_filesystem
 label: 'Quota inode amount'
-description: ''
+description: 'Number of files (inode quota)'
 required: false
 translatable: false
 default_value: {  }

--- a/web/sites/default/config/default/field.storage.paragraph.field_rp_node_count.yml
+++ b/web/sites/default/config/default/field.storage.paragraph.field_rp_node_count.yml
@@ -1,0 +1,20 @@
+uuid: 304f7296-ca49-4814-86e9-18ffd9d6e711
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_rp_node_count
+field_name: field_rp_node_count
+entity_type: paragraph
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
test coverage

Config: add field_rp_node_count (integer, "Number of nodes") to the rp_queue_spec paragraph with a number widget on the form; set the inode field description to "Number of files (inode quota)"; correct the account-setup field description (sidebar CTA, not Login section).

Cypress: assert node_count and the updated queue summaries in the resource API; assert the Nodes column and per-node CPU/GPU column labels on the resource page; assert the inherited account_setup link and the retry-then-unavailable behavior in the account panel, waiting on the intercepted request to remove fixed-timeout flakiness.

Refs D8-2772

## Describe context / purpose for this PR

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-2772-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
