### PR TITLE
feat(events): add mcp_my_events JSON:API view display

### DIFF
--- a/web/sites/default/config/default/views.view.event_instance_mine.yml
+++ b/web/sites/default/config/default/views.view.event_instance_mine.yml
@@ -821,3 +821,30 @@ display:
         - url.query_args
         - user
       tags: {  }
+  mcp_my_events:
+    id: mcp_my_events
+    display_title: 'MCP My Events'
+    display_plugin: page
+    position: 2
+    display_options:
+      defaults:
+        pager: false
+      exposed_block: true
+      display_extenders:
+        jsonapi_views:
+          enabled: true
+      path: mcp/my-events
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 100
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+      tags: {  }


### PR DESCRIPTION
The get_my_events MCP tool calls
/jsonapi/views/event_instance_mine/my_events_page?page[limit]=N and gets "Input value 'page' contains a non-scalar value" on every call — my_events_page inherits the default display's `full` pager, and full pagers reject page[limit] (they read `page` as a scalar page number).

Add a dedicated mcp_my_events display (path mcp/my-events, jsonapi_views enabled) with a `some` pager, which accepts page[limit] (as the working mcp_my_announcements view already does). The human /events/mine page (my_events_page, full pager) is untouched.

Includes defaults: { pager: false } — required so Views honors the pager override on a non-default display; without it the `some` pager is ignored and the default `full` pager still applies. The display adds no arguments/filters override, so it inherits the uid/current_user contextual argument from the default display (acting-user scoping preserved).

## Describe context / purpose for this PR

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
