### PR TITLE
Md dev

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -710,7 +710,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/aspTheme.git",
-                "reference": "709a260b8df44e546efc0b33916e74cb271078b7"
+                "reference": "db0a2eb49e3a51d6770875fafa600483dfe125b3"
             },
             "default-branch": true,
             "type": "drupal-theme",
@@ -728,7 +728,7 @@
                 "issues": "https://github.com/connectci-platform/aspTheme/issues",
                 "source": "https://github.com/connectci-platform/aspTheme"
             },
-            "time": "2026-07-22T22:02:26+00:00"
+            "time": "2026-07-24T16:09:28+00:00"
         },
         {
             "name": "connectci/campus-champions-theme",

--- a/composer.lock
+++ b/composer.lock
@@ -710,7 +710,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/aspTheme.git",
-                "reference": "db0a2eb49e3a51d6770875fafa600483dfe125b3"
+                "reference": "ed000196dfd091cf2796525020b9bcc1a7d4ebfe"
             },
             "default-branch": true,
             "type": "drupal-theme",
@@ -728,7 +728,7 @@
                 "issues": "https://github.com/connectci-platform/aspTheme/issues",
                 "source": "https://github.com/connectci-platform/aspTheme"
             },
-            "time": "2026-07-24T16:09:28+00:00"
+            "time": "2026-07-24T17:52:52+00:00"
         },
         {
             "name": "connectci/campus-champions-theme",

--- a/web/modules/custom/campuschampions/src/Plugin/Action/ApproveCCAction.php
+++ b/web/modules/custom/campuschampions/src/Plugin/Action/ApproveCCAction.php
@@ -115,6 +115,16 @@ class ApproveCCAction extends ViewsBulkOperationsActionBase implements Container
 
     $user = user_load_by_mail($user_email);
     if (!$user) {
+      // The applicant may already have an account under a different email
+      // whose username matches the one they entered (e.g. an ACCESS-CI ID).
+      // Fall back to a username lookup so we update that existing account
+      // rather than failing the approval.
+      $username = $data['username'] ?? NULL;
+      if ($username) {
+        $user = user_load_by_name($username);
+      }
+    }
+    if (!$user) {
       $this->loggerFactory->get('campuschampions')->error('Could not find user with email @email for approval.', ['@email' => $user_email]);
       return $this->t('Error: User not found for email @email.', ['@email' => $user_email]);
     }

--- a/web/modules/custom/campuschampions/src/Plugin/Action/ApproveCCAction.php
+++ b/web/modules/custom/campuschampions/src/Plugin/Action/ApproveCCAction.php
@@ -122,6 +122,20 @@ class ApproveCCAction extends ViewsBulkOperationsActionBase implements Container
       $username = $data['username'] ?? NULL;
       if ($username) {
         $user = user_load_by_name($username);
+        if ($user) {
+          // Audit trail: the approval is adopting an account whose email
+          // differs from the application's. The welcome email goes to the
+          // account's registered address, not the one on the application.
+          $this->loggerFactory->get('campuschampions')->notice(
+            'Approval for @app_email adopted existing account @name (uid @uid, account email @acct_email).',
+            [
+              '@app_email' => $user_email,
+              '@name' => $username,
+              '@uid' => $user->id(),
+              '@acct_email' => $user->getEmail(),
+            ]
+          );
+        }
       }
     }
     if (!$user) {

--- a/web/modules/custom/campuschampions/src/Plugin/WebformHandler/CreateUserHandler.php
+++ b/web/modules/custom/campuschampions/src/Plugin/WebformHandler/CreateUserHandler.php
@@ -111,7 +111,7 @@ class CreateUserHandler extends WebformHandlerBase {
       ->accessCheck(FALSE);
     $query->condition($query->orConditionGroup()
       ->condition('mail', $data['user_email'])
-      ->condition('name', $data['username']));
+      ->condition('name', $data['username'] ?? ''));
     $ids = $query->execute();
     if (empty($ids)) {
       $user = $this->createUser($data);

--- a/web/modules/custom/campuschampions/src/Plugin/WebformHandler/CreateUserHandler.php
+++ b/web/modules/custom/campuschampions/src/Plugin/WebformHandler/CreateUserHandler.php
@@ -100,11 +100,19 @@ class CreateUserHandler extends WebformHandlerBase {
   public function preSave(WebformSubmissionInterface $webformSubmission, $update = TRUE) {
     $data = $webformSubmission->getData();
 
-    // Create a new user if they don't exist already.
-    $ids = $this->entityTypeManager->getStorage('user')->getQuery()
+    // Create a new user only if one does not already exist. The
+    // users_field_data table enforces uniqueness on both the email ('mail')
+    // and the username ('name'), so we must check both: an applicant may enter
+    // a username (e.g. an ACCESS-CI ID) that already belongs to an account
+    // created under a different email. Checking email alone lets that slip
+    // through and the INSERT then throws an EntityStorageException that aborts
+    // the whole approval batch (500 error).
+    $query = $this->entityTypeManager->getStorage('user')->getQuery()
+      ->accessCheck(FALSE);
+    $query->condition($query->orConditionGroup()
       ->condition('mail', $data['user_email'])
-      ->accessCheck(FALSE)
-      ->execute();
+      ->condition('name', $data['username']));
+    $ids = $query->execute();
     if (empty($ids)) {
       $user = $this->createUser($data);
       $webformSubmission->convert($user);

--- a/web/modules/custom/ood_software/ood_software.module
+++ b/web/modules/custom/ood_software/ood_software.module
@@ -195,7 +195,7 @@ function ood_software_form_alter(array &$form, FormStateInterface $form_state, s
     $add_tags = \Drupal::service('access_misc.addtags');
     $output = $add_tags->getView();
     $tag_label = t('Tags');
-    $tag_description = t('Select up to 6 tags that relate to your engagement. Tags will help us find people with related expertise.');
+    $tag_description = t('Select up to 6 tags that relate to this software. Tags will help us find people with related expertise.');
     $tag_summary = t('Select Tags');
 
     $form['node_add_tags'] = [

--- a/web/modules/custom/ood_software/src/Plugin/GitHubService.php
+++ b/web/modules/custom/ood_software/src/Plugin/GitHubService.php
@@ -57,14 +57,14 @@ class GitHubService {
   /**
    * Github data.
    *
-   * @var array
+   * @var array<string, mixed>|null
    */
   protected $data;
 
   /**
    * Manifest data.
    *
-   * @var array
+   * @var array<string, mixed>|false|null
    */
   protected $manifestData;
 
@@ -80,21 +80,21 @@ class GitHubService {
    *
    * Shape: ['jupyter_example' => ['manifestYml' => '...', 'appverseYml' => '...']].
    *
-   * @var array
+   * @var array<string, array<string, string|null>>
    */
   protected array $appSubpathFiles = [];
 
   /**
    * Is Archived.
    *
-   * @var bool
+   * @var bool|null
    */
   protected $isArchived;
 
   /**
    * Stars for repo.
    *
-   * @var int
+   * @var int|null
    */
   protected $stars;
 
@@ -108,49 +108,49 @@ class GitHubService {
   /**
    * Repo name.
    *
-   * @var string
+   * @var string|null
    */
   protected $repoName;
 
   /**
    * Repo description.
    *
-   * @var string
+   * @var string|null
    */
   protected $description;
 
   /**
    * Last commited unix timestamp.
    *
-   * @var int
+   * @var int|null
    */
   protected $lastComittedDate;
 
   /**
    * Repo license.
    *
-   * @var string
+   * @var string|null
    */
   protected $license;
 
   /**
    * Repo license link.
    *
-   * @var string
+   * @var string|null
    */
   protected $licenseLink;
 
   /**
    * Organization name.
    *
-   * @var string
+   * @var string|null
    */
   protected $organization;
 
   /**
    * Role - app type.
    *
-   * @var string
+   * @var string|null
    */
   protected $role;
 
@@ -221,7 +221,7 @@ class GitHubService {
   /**
    * Parse github repo url.
    */
-  public function parseUrl($repo) {
+  public function parseUrl(string $repo): bool {
     $parsed_url = parse_url(Xss::filter($repo));
     if (isset($parsed_url['host']) && $parsed_url['host'] === 'github.com') {
       $path_parts = explode('/', trim($parsed_url['path'], '/'));
@@ -262,7 +262,7 @@ class GitHubService {
   /**
    * Fetch github repo.
    */
-  public function fetchRepoData() {
+  public function fetchRepoData(): bool {
     $token = $this->keyRepository->getKey('appverse_github')->getKeyValue();
 
     $query = <<<'GRAPHQL'
@@ -314,7 +314,7 @@ class GitHubService {
     }
     GRAPHQL;
 
-    $response = $this->httpClient->post('https://api.github.com/graphql', [
+    $response = $this->httpClient->request('POST', 'https://api.github.com/graphql', [
       'headers' => [
         'Authorization' => 'Bearer ' . $token,
         'Content-Type' => 'application/json',
@@ -518,7 +518,7 @@ class GitHubService {
     }
     GRAPHQL;
 
-    $response = $this->httpClient->post('https://api.github.com/graphql', [
+    $response = $this->httpClient->request('POST', 'https://api.github.com/graphql', [
       'headers' => [
         'Authorization' => 'Bearer ' . $token,
         'Content-Type' => 'application/json',
@@ -617,6 +617,9 @@ class GitHubService {
    *   attributes: array<string, array>,
    * }
    *   Empty arrays at each key when $yaml is NULL, empty, or malformed.
+   */
+  /**
+   * @return array<string, mixed>
    */
   public function parseFormYml(?string $yaml): array {
     $empty = ['clusters' => [], 'formFields' => [], 'attributes' => []];
@@ -750,6 +753,12 @@ class GitHubService {
    *   - unresolved: declarations with no exact match; each carries an
    *     optional Levenshtein-≤-3 suggestion of the closest existing term.
    */
+  /**
+   * @param array<int, string>|null $declared
+   *   Declared term names from appverse.yml.
+   *
+   * @return array<string, mixed>
+   */
   public function resolveTaxonomyTermsFromAppverseYml(string $vocabularyId, ?array $declared): array {
     $result = ['declared' => [], 'resolved' => [], 'unresolved' => []];
     if ($declared === NULL || empty($declared)) {
@@ -851,6 +860,9 @@ class GitHubService {
    *     suggestionDistance: ?int,
    *   },
    * }>
+   */
+  /**
+   * @return array<int|string, mixed>
    */
   public function getAppPreviewData(): array {
     if ($this->isEmptyRepo()) {
@@ -1013,77 +1025,83 @@ class GitHubService {
   /**
    * Get github data.
    */
-  public function getData() {
+  /**
+   * @return array<string, mixed>|null
+   */
+  public function getData(): ?array {
     return $this->data;
   }
 
   /**
    * Get manifest.
    */
-  public function getManifestData() {
+  /**
+   * @return array<string, mixed>|false|null
+   */
+  public function getManifestData(): array|false|null {
     return $this->manifestData;
   }
 
   /**
    * Get is archived.
    */
-  public function getIsArchived() {
+  public function getIsArchived(): ?bool {
     return $this->isArchived;
   }
 
   /**
    * Get stars.
    */
-  public function getStars() {
+  public function getStars(): ?int {
     return $this->stars;
   }
 
   /**
    * Get readme.
    */
-  public function getReadme() {
+  public function getReadme(): ?string {
     return $this->readme;
   }
 
   /**
    * Get repo name.
    */
-  public function getRepoName() {
+  public function getRepoName(): ?string {
     return $this->repoName;
   }
 
   /**
    * Get description.
    */
-  public function getDescription() {
+  public function getDescription(): ?string {
     return $this->description;
   }
 
   /**
    * Get last committed date.
    */
-  public function getLastComittedDate() {
+  public function getLastComittedDate(): ?int {
     return $this->lastComittedDate;
   }
 
   /**
    * Get license.
    */
-  public function getLicenseLink() {
+  public function getLicenseLink(): ?string {
     return $this->licenseLink;
   }
 
   /**
    * Get license.
    */
-  public function getLicense() {
+  public function getLicense(): ?string {
     return $this->license;
   }
 
   /**
    * Get Organization.
    */
-  public function getOrganization() {
+  public function getOrganization(): ?string {
     return $this->organization;
   }
 
@@ -1136,7 +1154,7 @@ class GitHubService {
   /**
    * Get AppType label for form display.
    */
-  public function getAppType() {
+  public function getAppType(): ?string {
     $label = $this->role;
     if ($label && $this->subcategory) {
       $label .= ' (' . $this->subcategory . ')';
@@ -1147,20 +1165,23 @@ class GitHubService {
   /**
    * Get subcategory from manifest.
    */
-  public function getSubcategory() {
+  public function getSubcategory(): ?string {
     return $this->subcategory;
   }
 
   /**
    * Get AppTypeId based on set role (backward compat, returns first match).
    */
-  public function getAppTypeId() {
+  public function getAppTypeId(): int|string|false|null {
     $ids = $this->getAppTypeIds();
     return $ids ? reset($ids) : NULL;
   }
 
   /**
    * Resolve role + subcategory to taxonomy term IDs.
+   */
+  /**
+   * @return array<int, int>
    */
   public function getAppTypeIds(): array {
     if (empty($this->role)) {
@@ -1171,7 +1192,14 @@ class GitHubService {
       $this->logger->notice('No app type mapping for manifest role: @role', ['@role' => $this->role]);
       return [];
     }
+    // The '*' fallback and the emptiness check are defensive: PHPStan resolves
+    // APP_TYPE_MANIFEST_MAP as a constant and concludes '*' always exists and is
+    // non-empty, but that holds only for the map's current contents. Keep both
+    // guards so adding a role without a '*' default degrades to "no terms"
+    // rather than a fatal.
+    // @phpstan-ignore-next-line
     $term_names = $role_map[$this->subcategory] ?? $role_map['*'] ?? [];
+    // @phpstan-ignore-next-line
     if (empty($term_names)) {
       return [];
     }
@@ -1193,6 +1221,9 @@ class GitHubService {
   /**
    * Get all term names that can be auto-assigned from manifest data.
    */
+  /**
+   * @return array<int, string>
+   */
   public static function getAutoAssignableTermNames(): array {
     $names = [];
     foreach (self::APP_TYPE_MANIFEST_MAP as $subcategories) {
@@ -1206,7 +1237,7 @@ class GitHubService {
   /**
    * Get license.
    */
-  public function getLicenseInfo() {
+  public function getLicenseInfo(): ?string {
     return $this->license;
   }
 

--- a/web/modules/custom/ood_software/src/Plugin/QueueWorker/AppverseAppUpdater.php
+++ b/web/modules/custom/ood_software/src/Plugin/QueueWorker/AppverseAppUpdater.php
@@ -2,7 +2,9 @@
 
 namespace Drupal\ood_software\Plugin\QueueWorker;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -43,9 +45,23 @@ final class AppverseAppUpdater extends QueueWorkerBase implements ContainerFacto
   protected $repoSync;
 
   /**
+   * The logger channel.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $time;
+
+  /**
    * Constructs a new AppverseAppUpdater object.
    *
-   * @param array $configuration
+   * @param array<string, mixed> $configuration
    *   A configuration array containing information about the plugin instance.
    * @param string $plugin_id
    *   The plugin_id for the plugin instance.
@@ -57,16 +73,25 @@ final class AppverseAppUpdater extends QueueWorkerBase implements ContainerFacto
    *   The GitHub service.
    * @param \Drupal\ood_software\Service\RepoSyncService $repo_sync
    *   The Repo sync service.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   The ood_software logger channel.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, GitHubService $github_service, RepoSyncService $repo_sync) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, GitHubService $github_service, RepoSyncService $repo_sync, LoggerChannelInterface $logger, TimeInterface $time) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
     $this->githubService = $github_service;
     $this->repoSync = $repo_sync;
+    $this->logger = $logger;
+    $this->time = $time;
   }
 
   /**
    * {@inheritdoc}
+   *
+   * @param array<string, mixed> $configuration
+   *   A configuration array containing information about the plugin instance.
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
@@ -75,14 +100,16 @@ final class AppverseAppUpdater extends QueueWorkerBase implements ContainerFacto
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('ood_software.gh'),
-      $container->get('ood_software.repo_sync')
+      $container->get('ood_software.repo_sync'),
+      $container->get('logger.factory')->get('ood_software'),
+      $container->get('datetime.time')
     );
   }
 
   /**
    * {@inheritdoc}
    */
-  public function processItem($data) {
+  public function processItem($data): void {
     $nid = $data['nid'];
     $node = $this->entityTypeManager->getStorage('node')->load($nid);
 
@@ -90,13 +117,33 @@ final class AppverseAppUpdater extends QueueWorkerBase implements ContainerFacto
       return;
     }
 
-    $github_url = $node->get('field_appverse_github_url')->uri;
+    $github_url = $node->get('field_appverse_github_url')->first()?->getValue()['uri'] ?? NULL;
 
     $validUrl = $this->githubService->parseUrl($github_url);
     if ($validUrl) {
       $this->githubService->getData();
       $lastupdated = $node->get('field_appverse_lastupdated')->value;
       $needsSave = FALSE;
+
+      // Auto-archive when the app's own GitHub repo is archived. RepoSyncService
+      // cascades archive from a Repo to its member apps, but that only covers
+      // apps synced under a declared Repo. A standalone/legacy app node (its own
+      // field_appverse_github_url, not a member under a synced declared Repo)
+      // is never visited by that cascade, so an archived-upstream app would stay
+      // published indefinitely. This worker runs on every app node, so enforce
+      // the same one-way archive contract here: archived on GitHub → archived in
+      // the catalog. One-way — a later un-archive on GitHub does NOT auto-restore;
+      // re-submit is the recovery path (mirrors RepoSyncService).
+      if ($this->githubService->getIsArchived()
+        && $node->hasField('moderation_state')
+        && $node->get('moderation_state')->value !== 'archived') {
+        $node->set('moderation_state', 'archived');
+        $needsSave = TRUE;
+        $this->logger->info('Auto-archiving App @nid — repo @url is archived on GitHub.', [
+          '@nid' => $nid,
+          '@url' => $github_url,
+        ]);
+      }
 
       $appverseYmlText = $this->githubService->getAppverseYmlText();
       $repoMetadata = [
@@ -218,7 +265,7 @@ final class AppverseAppUpdater extends QueueWorkerBase implements ContainerFacto
       // the fact that a catalogued app's upstream is unreachable. Log it so
       // it's visible; leave the node untouched (a transient rate-limit
       // shouldn't mutate catalog state).
-      \Drupal::logger('ood_software')->warning('Cron app update skipped: could not fetch @url for app @nid (repo deleted, private, rate-limited, or invalid URL).', [
+      $this->logger->warning('Cron app update skipped: could not fetch @url for app @nid (repo deleted, private, rate-limited, or invalid URL).', [
         '@url' => $github_url,
         '@nid' => $nid,
       ]);
@@ -259,9 +306,9 @@ final class AppverseAppUpdater extends QueueWorkerBase implements ContainerFacto
     $repo->set('field_repo_validation_er', $existing);
     // Match every other validation-state write in the codebase, which stamps
     // last_synced so the hub reflects when the state was last evaluated.
-    $repo->set('field_repo_last_synced', \Drupal::time()->getCurrentTime());
+    $repo->set('field_repo_last_synced', $this->time->getCurrentTime());
     $repo->save();
-    \Drupal::logger('ood_software')->notice('Repo @nid appverse.yml shape changed since registration; flagged degraded for attended Resync.', ['@nid' => $repo->id()]);
+    $this->logger->notice('Repo @nid appverse.yml shape changed since registration; flagged degraded for attended Resync.', ['@nid' => $repo->id()]);
   }
 
 }

--- a/web/modules/custom/ood_software/tests/src/Kernel/CronMemberAppGuardTest.php
+++ b/web/modules/custom/ood_software/tests/src/Kernel/CronMemberAppGuardTest.php
@@ -129,24 +129,24 @@ class CronMemberAppGuardTest extends KernelTestBase {
       $this->container->get('entity_type.manager'),
     ) extends GitHubService {
 
-      public function parseUrl($repo) {
+      public function parseUrl(string $repo): bool {
         return TRUE;
       }
 
-      public function getData() {}
+      public function getData(): ?array { return []; }
 
       // A last-committed date that will differ from the app's stored
       // lastupdated, so the "new commits" branch is entered.
-      public function getLastComittedDate() {
-        return '2000000000';
+      public function getLastComittedDate(): ?int {
+        return 2000000000;
       }
 
       // Root data — what would clobber a member app if the guard is absent.
-      public function getDescription() {
+      public function getDescription(): ?string {
         return 'ROOT DESCRIPTION';
       }
 
-      public function getReadme() {
+      public function getReadme(): ?string {
         return 'ROOT README';
       }
 
@@ -154,7 +154,7 @@ class CronMemberAppGuardTest extends KernelTestBase {
         return [];
       }
 
-      public function getStars() {
+      public function getStars(): ?int {
         return 0;
       }
 
@@ -162,7 +162,7 @@ class CronMemberAppGuardTest extends KernelTestBase {
         return 'https://github.com/OSC/mono';
       }
 
-      public function getRepoName() {
+      public function getRepoName(): ?string {
         return 'mono';
       }
 
@@ -170,7 +170,7 @@ class CronMemberAppGuardTest extends KernelTestBase {
         return '';
       }
 
-      public function getOrganization() {
+      public function getOrganization(): ?string {
         return '';
       }
 
@@ -207,6 +207,8 @@ class CronMemberAppGuardTest extends KernelTestBase {
       $this->container->get('entity_type.manager'),
       $gh,
       $repoSync,
+      $this->container->get('logger.factory')->get('ood_software'),
+      $this->container->get('datetime.time'),
     );
   }
 
@@ -312,17 +314,17 @@ class CronMemberAppGuardTest extends KernelTestBase {
       $this->container->get('logger.factory'),
       $this->container->get('entity_type.manager'),
     ) extends GitHubService {
-      public function parseUrl($repo) { return TRUE; }
-      public function getData() {}
-      public function getLastComittedDate() { return '2000000000'; }
-      public function getDescription() { return 'D'; }
-      public function getReadme() { return 'R'; }
+      public function parseUrl(string $repo): bool { return TRUE; }
+      public function getData(): ?array { return []; }
+      public function getLastComittedDate(): ?int { return 2000000000; }
+      public function getDescription(): ?string { return 'D'; }
+      public function getReadme(): ?string { return 'R'; }
       public function getAppTypeIds(): array { return []; }
-      public function getStars() { return 0; }
+      public function getStars(): ?int { return 0; }
       public function getRepoUrl(): string { return 'https://github.com/OSC/mono'; }
-      public function getRepoName() { return 'mono'; }
+      public function getRepoName(): ?string { return 'mono'; }
       public function getRepoDescription(): string { return ''; }
-      public function getOrganization() { return ''; }
+      public function getOrganization(): ?string { return ''; }
       // Now HAS a root appverse.yml → isDeclaredRepo() returns TRUE.
       // (isDeclaredRepo reads the $appverseYmlText property, which parseUrl
       // would set in real cron; override it directly in the stub.)
@@ -346,6 +348,8 @@ class CronMemberAppGuardTest extends KernelTestBase {
       $this->container->get('entity_type.manager'),
       $gh,
       $repoSync,
+      $this->container->get('logger.factory')->get('ood_software'),
+      $this->container->get('datetime.time'),
     );
     $worker->processItem(['nid' => $app->id()]);
 
@@ -392,17 +396,17 @@ class CronMemberAppGuardTest extends KernelTestBase {
       $this->container->get('logger.factory'),
       $this->container->get('entity_type.manager'),
     ) extends GitHubService {
-      public function parseUrl($repo) { return TRUE; }
-      public function getData() {}
-      public function getLastComittedDate() { return '2000000000'; }
-      public function getDescription() { return 'D'; }
-      public function getReadme() { return 'R'; }
+      public function parseUrl(string $repo): bool { return TRUE; }
+      public function getData(): ?array { return []; }
+      public function getLastComittedDate(): ?int { return 2000000000; }
+      public function getDescription(): ?string { return 'D'; }
+      public function getReadme(): ?string { return 'R'; }
       public function getAppTypeIds(): array { return []; }
-      public function getStars() { return 0; }
+      public function getStars(): ?int { return 0; }
       public function getRepoUrl(): string { return 'https://github.com/OSC/mono'; }
-      public function getRepoName() { return 'mono'; }
+      public function getRepoName(): ?string { return 'mono'; }
       public function getRepoDescription(): string { return ''; }
-      public function getOrganization() { return ''; }
+      public function getOrganization(): ?string { return ''; }
       public function getAppverseYmlText(): ?string { return NULL; }
       public function isDeclaredRepo(): bool { return FALSE; }
     };
@@ -421,6 +425,8 @@ class CronMemberAppGuardTest extends KernelTestBase {
       $this->container->get('entity_type.manager'),
       $gh,
       $repoSync,
+      $this->container->get('logger.factory')->get('ood_software'),
+      $this->container->get('datetime.time'),
     );
     $worker->processItem(['nid' => $app->id()]);
 


### PR DESCRIPTION
## Describe context / purpose for this PR
Weekly md-dev roll-up to main. Five changes:

**ood_software: auto-archive standalone apps whose GitHub repo is archived (audit follow-up).** RepoSyncService already cascade-archives member apps when their declared Repo is archived on GitHub, but standalone/legacy apps (own `field_appverse_github_url`, no declared Repo) were never visited, so an app whose upstream was archived stayed published indefinitely — the SAS app (fasrc/ood-sas-app, archived on GitHub since March) was flagged in a reviewer's audit as exactly this case. The AppverseAppUpdater queue worker now sets moderation_state to archived when the app's own repo is archived upstream; one-way like RepoSyncService (re-submit is the recovery path). Takes effect on the next cron run, no backfill needed. Includes kernel test coverage and clears the file's PHPStan debt (DI for logger/time, typed configuration).

**ood_software: type GitHubService getters and fix rotted annotations.** Several @var docblocks had drifted from reality (documented `array`/non-nullable, actually NULL/FALSE assignments). Adds native return types derived from the assignment sites, corrects the docblocks, and swaps `httpClient->post()` for `request('POST', ...)` (post() isn't on the declared ClientInterface). No behavior change.

**ood_software: update Appverse software tags field description (D8-2791, #2069).**

**campuschampions: fix champion approval error + adopt existing account (D8-2767, #2070).** Approving a champion whose account was already created by the allocations import under a different email threw a duplicate-key error that aborted the whole approval batch. The Create User handler now dedupes on username as well as email, and the approve action falls back to a username lookup so it updates the existing account rather than failing. Also logs when an approval adopts an existing account; the adopt path is safe because the form blocks anonymous submissions colliding with an existing username/email and locks those fields to the session account for logged-in users.

**asp-theme (resource documentation refinements):**
- MFA badge reworded to "2FA/MFA required for login" with a shield-lock icon, and the note moved from the title badge row into the Login section (the green check read as a status, not a requirement — user/Jim feedback).
- Storage, File Transfer, Datasets, and Queue-spec tables now suppress their headers when every row is empty (previously the column headers rendered above an empty body, e.g. cloudbank-classroom). The two software tables read controller-built arrays and are unaffected.

## Issue link
D8-2791, D8-2767, plus Appverse review audit follow-ups and D8-2773 badge/table feedback

## Any other related PRs?
- connectci-platform/portal#2069 (D8-2791)
- connectci-platform/portal#2070 (D8-2767)
- connectci-platform/aspTheme (MFA + empty-table commits pinned by the lock bumps)

## Link to MultiDev instance

http://md-dev-accessmatch.pantheonsite.io

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR