### PR TITLE
feat(ood_software): sync reviewer checklist and rubric from appverse-review

### DIFF
--- a/web/modules/custom/ood_software/src/Service/DocSyncService.php
+++ b/web/modules/custom/ood_software/src/Service/DocSyncService.php
@@ -33,18 +33,20 @@ class DocSyncService {
   protected $logger;
 
   /**
-   * Map of GitHub doc filenames to Drupal node IDs.
+   * Map of GitHub raw doc URLs to Drupal node IDs.
+   *
+   * Each doc is synced from its canonical repo. Review-skill docs (the
+   * reviewer checklist and the security rubric) are maintained in the
+   * appverse-review plugin repo under references/; broader Appverse docs
+   * live in ood-appverse under docs/. The URL is the full raw.githubusercontent
+   * path so a single map can span repos and subpaths.
    */
   public const DOC_MAP = [
-    'appverse-contributor-guide.md' => 11929,
-    'app-best-practices.md' => 11933,
-    'app-review-checklist.md' => 11932,
+    'https://raw.githubusercontent.com/Sweet-and-Fizzy/appverse-review/main/references/review-checklist.md' => 11932,
+    'https://raw.githubusercontent.com/Sweet-and-Fizzy/appverse-review/main/references/security-rubric.md' => 12246,
+    'https://raw.githubusercontent.com/sweet-and-fizzy/ood-appverse/main/docs/appverse-contributor-guide.md' => 11929,
+    'https://raw.githubusercontent.com/sweet-and-fizzy/ood-appverse/main/docs/app-best-practices.md' => 11933,
   ];
-
-  /**
-   * GitHub raw content base URL.
-   */
-  protected const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/sweet-and-fizzy/ood-appverse/main/docs/';
 
   /**
    * Constructs a DocSyncService object.
@@ -58,22 +60,28 @@ class DocSyncService {
   /**
    * Sync all mapped docs from GitHub to Drupal nodes.
    */
-  public function syncAll() {
-    foreach (self::DOC_MAP as $filename => $nid) {
-      $this->syncDoc($filename, $nid);
+  public function syncAll(): void {
+    foreach (self::DOC_MAP as $url => $nid) {
+      $this->syncDoc($url, $nid);
     }
   }
 
   /**
    * Sync a single doc from GitHub to a Drupal node.
    *
-   * @param string $filename
-   *   The markdown filename in the docs directory.
+   * @param string $url
+   *   The full raw.githubusercontent URL of the markdown source.
    * @param int $nid
    *   The Drupal node ID to update.
    */
-  protected function syncDoc($filename, $nid) {
-    $url = self::GITHUB_RAW_BASE . $filename;
+  protected function syncDoc($url, $nid): void {
+    // A nid of 0 marks a doc whose Drupal node has not been created yet.
+    // Skip it so the sync does not error until the node exists.
+    if (empty($nid)) {
+      return;
+    }
+
+    $filename = basename($url);
 
     try {
       $response = $this->httpClient->request('GET', $url, [
@@ -115,8 +123,9 @@ class DocSyncService {
     // catalog in sync without a separate discovery API endpoint.
     $markdown = $this->substituteVocabularyTokens($markdown);
 
-    $current_body = $node->get('body')->value;
-    $current_format = $node->get('body')->format;
+    $body_item = $node->get('body')->first();
+    $current_body = $body_item?->getValue()['value'] ?? NULL;
+    $current_format = $body_item?->getValue()['format'] ?? NULL;
 
     // Only save if content actually changed.
     if ($current_body === $markdown && $current_format === 'markdown') {


### PR DESCRIPTION
DocSyncService pulled all four review docs from ood-appverse/docs/. Two of them — the reviewer checklist and the security rubric — are actually maintained in the appverse-review plugin repo under references/; the ood-appverse checklist was a fork that had drifted two months stale, and the rubric had no published home at all.

Point the checklist and rubric entries at appverse-review/main/references/, and add the security rubric as a new doc mapped to node 12246. The contributor guide and best-practices docs stay on ood-appverse, where they are canonical.

The map now spans two repos, so DOC_MAP keys are full raw.githubusercontent URLs and syncDoc fetches the URL directly (basename() for log labels). A nid of 0 marks a doc whose Drupal node does not exist yet and is skipped. appverse-review is public, so both new raw URLs resolve.

Also clear the file's pre-existing PHPStan debt so it passes the pre-commit gate: add void return types on syncAll()/syncDoc() and read the body field's value/format via first()?->getValue() instead of undefined magic properties.

## Describe context / purpose for this PR

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-dev-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
