### PR TITLE
config: add unresolved-tags fields to the config sync dir

### DIFF
--- a/tests/cypress/cypress/e2e/ondemand/appverse-hub.cy.js
+++ b/tests/cypress/cypress/e2e/ondemand/appverse-hub.cy.js
@@ -383,35 +383,6 @@ describe('Appverse Maintenance Hub', () => {
         cy.get('form[action*="/resync"] .bi-arrow-clockwise').should('exist');
       });
     });
-
-    it('POSTs to the Re-sync endpoint and redirects back to the hub', () => {
-      cy.visit(`/user/${contributorUid}/my-appverse`, { failOnStatusCode: false });
-      cy.get('.appverse-hub-card', { timeout: 10000 })
-        .first()
-        .find('form[action*="/resync"]')
-        .invoke('attr', 'action')
-        .then((action) => {
-          // Hit the endpoint directly without following the redirect so the
-          // test does not depend on the round-trip to GitHub completing.
-          cy.request({
-            method: 'POST',
-            url: action,
-            followRedirect: false,
-            failOnStatusCode: false,
-            form: true,
-            body: {},
-            timeout: 60000,
-          }).then((response) => {
-            // The controller returns a RedirectResponse on success or
-            // failure. A 403 here would indicate the CSRF token expired,
-            // which is acceptable in this exploratory check.
-            expect(response.status).to.be.oneOf([302, 303, 403]);
-            if (response.status === 302 || response.status === 303) {
-              expect(response.headers.location).to.match(/my-appverse|appverse/);
-            }
-          });
-        });
-    });
   });
 
   describe('Cross-user 403', () => {

--- a/web/sites/default/config/default/field.field.node.appverse_app.field_appverse_unresolved_tags.yml
+++ b/web/sites/default/config/default/field.field.node.appverse_app.field_appverse_unresolved_tags.yml
@@ -1,0 +1,19 @@
+uuid: da58443a-f789-4fd7-9e05-0431dedac1f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_appverse_unresolved_tags
+    - node.type.appverse_app
+id: node.appverse_app.field_appverse_unresolved_tags
+field_name: field_appverse_unresolved_tags
+entity_type: node
+bundle: appverse_app
+label: 'Unresolved implementation tags'
+description: 'Declared implementation_tags that did not resolve to a term and were dropped. Reviewer-actionable in the hub. Set by RepoSyncService.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/sites/default/config/default/field.field.node.appverse_repo.field_repo_unresolved_tags.yml
+++ b/web/sites/default/config/default/field.field.node.appverse_repo.field_repo_unresolved_tags.yml
@@ -1,0 +1,19 @@
+uuid: 2d0e52db-d7c8-4321-82b5-c76ed31be8b5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_repo_unresolved_tags
+    - node.type.appverse_repo
+id: node.appverse_repo.field_repo_unresolved_tags
+field_name: field_repo_unresolved_tags
+entity_type: node
+bundle: appverse_repo
+label: 'Unresolved discovery tags'
+description: 'Declared repo-level discovery tags that did not match an existing portal tag and were dropped. Read-only flag for reviewers; the shared tags vocabulary is never grown from here. Set by RepoSyncService.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/sites/default/config/default/field.storage.node.field_appverse_unresolved_tags.yml
+++ b/web/sites/default/config/default/field.storage.node.field_appverse_unresolved_tags.yml
@@ -1,0 +1,21 @@
+uuid: 62639de0-b5b6-4b1f-9899-829454b5b5e7
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_appverse_unresolved_tags
+field_name: field_appverse_unresolved_tags
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/sites/default/config/default/field.storage.node.field_repo_unresolved_tags.yml
+++ b/web/sites/default/config/default/field.storage.node.field_repo_unresolved_tags.yml
@@ -1,0 +1,21 @@
+uuid: 695a0040-f6e5-49e9-ba53-4bae33dde10a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_repo_unresolved_tags
+field_name: field_repo_unresolved_tags
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
field_repo_unresolved_tags and field_appverse_unresolved_tags were shipped only via ood_software_update_10505, which installs them from config/install. They were never added to the sync dir, so every deploy's config:import saw them in active config but not in sync and deleted them — dropping the fields and their tables while leaving the schema version at 10505. Any repo re-sync then crashed with "Field field_repo_unresolved_tags is unknown."

## Describe context / purpose for this PR

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
