### PR TITLE
Appverse jsonapi unresolved tags

### DIFF
--- a/web/sites/default/config/default/core.entity_form_display.node.appverse_app.default.yml
+++ b/web/sites/default/config/default/core.entity_form_display.node.appverse_app.default.yml
@@ -5,15 +5,20 @@ dependencies:
   config:
     - field.field.node.appverse_app.body
     - field.field.node.appverse_app.field_add_implementation_tags
+    - field.field.node.appverse_app.field_appverse_app_subpath
     - field.field.node.appverse_app.field_appverse_app_type
-    - field.field.node.appverse_app.field_appverse_repo
+    - field.field.node.appverse_app.field_appverse_app_validation_er
+    - field.field.node.appverse_app.field_appverse_app_validation_st
     - field.field.node.appverse_app.field_appverse_github_url
     - field.field.node.appverse_app.field_appverse_lastupdated
     - field.field.node.appverse_app.field_appverse_license_link
+    - field.field.node.appverse_app.field_appverse_maintainer_name
     - field.field.node.appverse_app.field_appverse_organization
     - field.field.node.appverse_app.field_appverse_readme
+    - field.field.node.appverse_app.field_appverse_repo
     - field.field.node.appverse_app.field_appverse_software_implemen
     - field.field.node.appverse_app.field_appverse_stars
+    - field.field.node.appverse_app.field_appverse_unresolved_tags
     - field.field.node.appverse_app.field_domain_access
     - field.field.node.appverse_app.field_domain_all_affiliates
     - field.field.node.appverse_app.field_domain_source
@@ -225,6 +230,7 @@ hidden:
   field_appverse_app_validation_st: true
   field_appverse_maintainer_name: true
   field_appverse_stars: true
+  field_appverse_unresolved_tags: true
   field_domain_access: true
   field_domain_all_affiliates: true
   field_domain_source: true

--- a/web/sites/default/config/default/core.entity_form_display.node.appverse_repo.default.yml
+++ b/web/sites/default/config/default/core.entity_form_display.node.appverse_repo.default.yml
@@ -12,11 +12,12 @@ dependencies:
     - field.field.node.appverse_repo.field_repo_organization
     - field.field.node.appverse_repo.field_repo_readme
     - field.field.node.appverse_repo.field_repo_related
-    - field.field.node.appverse_repo.field_repo_url
     - field.field.node.appverse_repo.field_repo_shape
     - field.field.node.appverse_repo.field_repo_shared_paths
     - field.field.node.appverse_repo.field_repo_stars
     - field.field.node.appverse_repo.field_repo_tags
+    - field.field.node.appverse_repo.field_repo_unresolved_tags
+    - field.field.node.appverse_repo.field_repo_url
     - field.field.node.appverse_repo.field_repo_validation_er
     - field.field.node.appverse_repo.field_repo_validation_st
     - field.field.node.appverse_repo.field_repo_www_url
@@ -117,6 +118,7 @@ hidden:
   field_repo_shared_paths: true
   field_repo_stars: true
   field_repo_tags: true
+  field_repo_unresolved_tags: true
   field_repo_url: true
   field_repo_validation_er: true
   field_repo_validation_st: true

--- a/web/sites/default/config/default/core.entity_view_display.node.appverse_app.default.yml
+++ b/web/sites/default/config/default/core.entity_view_display.node.appverse_app.default.yml
@@ -7,15 +7,18 @@ dependencies:
     - field.field.node.appverse_app.field_add_implementation_tags
     - field.field.node.appverse_app.field_appverse_app_subpath
     - field.field.node.appverse_app.field_appverse_app_type
-    - field.field.node.appverse_app.field_appverse_repo
+    - field.field.node.appverse_app.field_appverse_app_validation_er
+    - field.field.node.appverse_app.field_appverse_app_validation_st
     - field.field.node.appverse_app.field_appverse_github_url
     - field.field.node.appverse_app.field_appverse_lastupdated
     - field.field.node.appverse_app.field_appverse_license_link
     - field.field.node.appverse_app.field_appverse_maintainer_name
     - field.field.node.appverse_app.field_appverse_organization
     - field.field.node.appverse_app.field_appverse_readme
+    - field.field.node.appverse_app.field_appverse_repo
     - field.field.node.appverse_app.field_appverse_software_implemen
     - field.field.node.appverse_app.field_appverse_stars
+    - field.field.node.appverse_app.field_appverse_unresolved_tags
     - field.field.node.appverse_app.field_domain_access
     - field.field.node.appverse_app.field_domain_all_affiliates
     - field.field.node.appverse_app.field_domain_source
@@ -155,6 +158,7 @@ hidden:
   field_appverse_app_validation_er: true
   field_appverse_app_validation_st: true
   field_appverse_stars: true
+  field_appverse_unresolved_tags: true
   field_domain_access: true
   field_domain_all_affiliates: true
   field_domain_source: true

--- a/web/sites/default/config/default/core.entity_view_display.node.appverse_app.teaser.yml
+++ b/web/sites/default/config/default/core.entity_view_display.node.appverse_app.teaser.yml
@@ -6,14 +6,20 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.appverse_app.body
     - field.field.node.appverse_app.field_add_implementation_tags
+    - field.field.node.appverse_app.field_appverse_app_subpath
     - field.field.node.appverse_app.field_appverse_app_type
+    - field.field.node.appverse_app.field_appverse_app_validation_er
+    - field.field.node.appverse_app.field_appverse_app_validation_st
     - field.field.node.appverse_app.field_appverse_github_url
     - field.field.node.appverse_app.field_appverse_lastupdated
     - field.field.node.appverse_app.field_appverse_license_link
+    - field.field.node.appverse_app.field_appverse_maintainer_name
     - field.field.node.appverse_app.field_appverse_organization
     - field.field.node.appverse_app.field_appverse_readme
+    - field.field.node.appverse_app.field_appverse_repo
     - field.field.node.appverse_app.field_appverse_software_implemen
     - field.field.node.appverse_app.field_appverse_stars
+    - field.field.node.appverse_app.field_appverse_unresolved_tags
     - field.field.node.appverse_app.field_domain_access
     - field.field.node.appverse_app.field_domain_all_affiliates
     - field.field.node.appverse_app.field_domain_source
@@ -65,6 +71,7 @@ hidden:
   field_appverse_repo: true
   field_appverse_software_implemen: true
   field_appverse_stars: true
+  field_appverse_unresolved_tags: true
   field_domain_access: true
   field_domain_all_affiliates: true
   field_domain_source: true

--- a/web/sites/default/config/default/core.entity_view_display.node.appverse_repo.default.yml
+++ b/web/sites/default/config/default/core.entity_view_display.node.appverse_repo.default.yml
@@ -5,13 +5,21 @@ dependencies:
   config:
     - field.field.node.appverse_repo.field_repo_description
     - field.field.node.appverse_repo.field_repo_docs_url
+    - field.field.node.appverse_repo.field_repo_last_commit
     - field.field.node.appverse_repo.field_repo_last_synced
     - field.field.node.appverse_repo.field_repo_maintainer_name
     - field.field.node.appverse_repo.field_repo_maintainer_url
     - field.field.node.appverse_repo.field_repo_organization
     - field.field.node.appverse_repo.field_repo_readme
-    - field.field.node.appverse_repo.field_repo_url
+    - field.field.node.appverse_repo.field_repo_related
+    - field.field.node.appverse_repo.field_repo_shape
+    - field.field.node.appverse_repo.field_repo_shared_paths
+    - field.field.node.appverse_repo.field_repo_stars
     - field.field.node.appverse_repo.field_repo_tags
+    - field.field.node.appverse_repo.field_repo_unresolved_tags
+    - field.field.node.appverse_repo.field_repo_url
+    - field.field.node.appverse_repo.field_repo_validation_er
+    - field.field.node.appverse_repo.field_repo_validation_st
     - field.field.node.appverse_repo.field_repo_www_url
     - node.type.appverse_repo
   module:
@@ -135,6 +143,7 @@ hidden:
   field_repo_shape: true
   field_repo_shared_paths: true
   field_repo_stars: true
+  field_repo_unresolved_tags: true
   field_repo_validation_er: true
   field_repo_validation_st: true
   langcode: true

--- a/web/sites/default/config/default/jsonapi_extras.jsonapi_resource_config.node--appverse_app.yml
+++ b/web/sites/default/config/default/jsonapi_extras.jsonapi_resource_config.node--appverse_app.yml
@@ -90,3 +90,45 @@ resourceFields:
     publicName: field_appverse_stars
     enhancer:
       id: ''
+  field_appverse_unresolved_tags:
+    disabled: false
+    fieldName: field_appverse_unresolved_tags
+    publicName: field_appverse_unresolved_tags
+    enhancer:
+      id: ''
+  body:
+    disabled: false
+    fieldName: body
+    publicName: body
+    enhancer:
+      id: ''
+  field_license:
+    disabled: false
+    fieldName: field_license
+    publicName: field_license
+    enhancer:
+      id: ''
+  field_add_implementation_tags:
+    disabled: false
+    fieldName: field_add_implementation_tags
+    publicName: field_add_implementation_tags
+    enhancer:
+      id: ''
+  field_domain_access:
+    disabled: true
+    fieldName: field_domain_access
+    publicName: field_domain_access
+    enhancer:
+      id: ''
+  field_domain_all_affiliates:
+    disabled: true
+    fieldName: field_domain_all_affiliates
+    publicName: field_domain_all_affiliates
+    enhancer:
+      id: ''
+  field_domain_source:
+    disabled: true
+    fieldName: field_domain_source
+    publicName: field_domain_source
+    enhancer:
+      id: ''

--- a/web/sites/default/config/default/jsonapi_extras.jsonapi_resource_config.node--appverse_app.yml
+++ b/web/sites/default/config/default/jsonapi_extras.jsonapi_resource_config.node--appverse_app.yml
@@ -115,19 +115,19 @@ resourceFields:
     enhancer:
       id: ''
   field_domain_access:
-    disabled: true
+    disabled: false
     fieldName: field_domain_access
     publicName: field_domain_access
     enhancer:
       id: ''
   field_domain_all_affiliates:
-    disabled: true
+    disabled: false
     fieldName: field_domain_all_affiliates
     publicName: field_domain_all_affiliates
     enhancer:
       id: ''
   field_domain_source:
-    disabled: true
+    disabled: false
     fieldName: field_domain_source
     publicName: field_domain_source
     enhancer:

--- a/web/sites/default/config/default/jsonapi_extras.jsonapi_resource_config.node--appverse_repo.yml
+++ b/web/sites/default/config/default/jsonapi_extras.jsonapi_resource_config.node--appverse_repo.yml
@@ -114,3 +114,9 @@ resourceFields:
     publicName: field_repo_shape
     enhancer:
       id: ''
+  field_repo_unresolved_tags:
+    disabled: false
+    fieldName: field_repo_unresolved_tags
+    publicName: field_repo_unresolved_tags
+    enhancer:
+      id: ''


### PR DESCRIPTION
## What

Registers the appverse unresolved-tags fields (and the remaining unregistered `appverse_app` fields) in their JSON:API Extras resource configs, and re-exports the appverse entity displays to match the current bundles.

## Why

`field_repo_unresolved_tags` and `field_appverse_unresolved_tags` were added to the bundles (config sync PR #2074) but not to their JSON:API Extras resource configs. JSON:API Extras runs a config-import integrity check that fails on any changed field missing from its resource config, which aborts the entire `config:import`. On every deploy the import rolled back, so the fields never landed on live and re-sync crashed with `Field field_repo_unresolved_tags is unknown`.

## Changes

- Register both unresolved-tags fields, plus the remaining unconfigured `appverse_app` bundle fields (`body`, `field_license`, `field_add_implementation_tags`, and the three `field_domain_*` fields), so the resource configs fully describe the bundles and the integrity check passes. All are registered with `disabled: false`, matching current live API exposure — a no-op on what the API returns.
- Re-export the 5 appverse entity displays so their dependencies and hidden-field lists match the current bundles. No fields are newly shown; visible layouts are unchanged.

## Testing

`config:import` dry-run on live imports cleanly (integrity passes). The `ondemand` Cypress suite creates apps through the JSON:API, which writes the required `field_domain_access` — kept exposed so that path works.
