### PR TITLE
style(hub): make the maintenance hub cards usable on mobile

### DIFF
--- a/web/modules/custom/ood_software/css/appverse-hub.css
+++ b/web/modules/custom/ood_software/css/appverse-hub.css
@@ -84,6 +84,23 @@ header:has(> .appverse-hub-add-repo) {
   font-size: 0.9em;
   margin-top: 0.5rem;
 }
+/* On narrow screens the 5-column table can't fit; rather than let it blow out
+   the page width (and push the Status column off-screen), let the table scroll
+   horizontally within the card. `display: block` makes the <table> itself the
+   scroll container without needing a wrapper element in the template. */
+@media (max-width: 768px) {
+  .appverse-hub-apps-table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    white-space: nowrap;
+  }
+  /* Keep the status badge + edit control from wrapping mid-scroll. */
+  .appverse-hub-apps-table th,
+  .appverse-hub-apps-table td { white-space: nowrap; }
+  /* Tags can still wrap within their cell — they're the one flexible column. */
+  .appverse-hub-apps-table__tags { white-space: normal; }
+}
 .appverse-hub-apps-table th,
 .appverse-hub-apps-table td {
   padding: 0.4rem 0.6rem;
@@ -272,8 +289,56 @@ header:has(> .appverse-hub-add-repo) {
 @media (max-width: 768px) {
   .appverse-hub-card__header {
     grid-template-columns: 1fr;
+    row-gap: 0.75rem;
   }
   .appverse-hub-card__cell--actions { justify-content: flex-start; }
+
+  /* Stacked, the cells lose the column-position that gave them meaning: a lone
+     badge or timestamp reads as unlabeled. Prefix each data cell with its label
+     so status, sync time, owner, etc. are identifiable on a phone. The title
+     needs no label; the desktop layout (grid columns) is unaffected. */
+  .appverse-hub-card__cell--sync::before,
+  .appverse-hub-card__cell--github::before,
+  .appverse-hub-card__cell--owner::before,
+  .appverse-hub-card__cell--status::before,
+  .appverse-hub-card__cell--actions::before {
+    flex: 0 0 5.5rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #57606a;
+  }
+  .appverse-hub-card__cell--status::before  { content: 'Status'; }
+  .appverse-hub-card__cell--github::before  { content: 'Source'; }
+  .appverse-hub-card__cell--owner::before   { content: 'Maintainer'; }
+  .appverse-hub-card__cell--actions::before { content: 'Actions'; }
+
+  /* The sync cell already reads "Last sync <ts>" in its span, so it needs no
+     label — but keep the same label-column indent (empty) so its content lines
+     up with the labeled rows instead of floating at the card's left edge. */
+  .appverse-hub-card__cell--sync::before {
+    content: '';
+    flex: 0 0 5.5rem;
+  }
+  .appverse-hub-card__last-synced { white-space: normal; }
+
+  /* Empty cells (e.g. owner on your own hub, or an absent github link) would
+     otherwise render a stray label with no value. Hide any data cell that has
+     no rendered content. :has() is supported on all current mobile engines;
+     the desktop grid keeps empty cells for alignment above this breakpoint. */
+  .appverse-hub-card__cell--github:not(:has(a)),
+  .appverse-hub-card__cell--owner:not(:has(a)),
+  .appverse-hub-card__cell--actions:not(:has(a, button)) {
+    display: none;
+  }
+
+  /* Bigger tap targets on touch-sized screens: the 2rem icon buttons are below
+     the ~44px comfortable-touch minimum. */
+  .appverse-hub-card__icon-btn {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
 }
 .appverse-hub-card__owner {
   font-weight: 600;


### PR DESCRIPTION
The hub card header is a fixed-column grid that collapsed to a single column under 768px, leaving each cell's value unlabeled — a lone status badge or timestamp with no indication of what it was. On a phone the publish status was effectively invisible, and the member-apps table overflowed the viewport, pushing the per-app Status column off-screen.

Within the existing 768px breakpoint:
- Label the stacked header cells (Status, Source, Maintainer, Actions) so each value is identifiable, and align the sync timestamp to the label column.
- Hide cells with no content (e.g. the maintainer cell on your own hub) so they don't render a stray label.
- Contain the member-apps table's overflow with horizontal scroll instead of letting it blow out the page width.
- Enlarge the icon-button tap targets to ~44px.

Desktop layout is unchanged — all rules are scoped inside the mobile media queries.

## Describe context / purpose for this PR

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
