### PR TITLE
fix(docs): derive the GitHub edit link from each doc's real source

### DIFF
--- a/web/modules/custom/ood_software/ood_software.module
+++ b/web/modules/custom/ood_software/ood_software.module
@@ -1477,18 +1477,28 @@ function ood_software_node_view(array &$build, EntityInterface $entity, EntityVi
       ],
     ];
 
-    $github_url = 'https://github.com/sweet-and-fizzy/ood-appverse/edit/main/docs/' . $doc_map[$nid];
-    $build['github_edit_link'] = [
-      '#type' => 'container',
-      '#attributes' => ['class' => ['appverse-docs-github-link']],
-      '#weight' => -100,
-      'link' => [
-        '#type' => 'link',
-        '#title' => 'Suggest an edit on GitHub',
-        '#url' => \Drupal\Core\Url::fromUri($github_url),
-        '#attributes' => ['target' => '_blank', 'rel' => 'noopener'],
-      ],
-    ];
+    // Derive the GitHub edit URL from the doc's raw source URL, since docs come
+    // from two repos (ood-appverse/docs and appverse-review/references).
+    $source_url = $doc_map[$nid];
+    $github_url = preg_replace(
+      '#^https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/([^/]+)/(.+)$#',
+      'https://github.com/$1/$2/edit/$3/$4',
+      $source_url
+    );
+    // Only render the link when the transform matched a raw URL.
+    if ($github_url && $github_url !== $source_url) {
+      $build['github_edit_link'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['appverse-docs-github-link']],
+        '#weight' => -100,
+        'link' => [
+          '#type' => 'link',
+          '#title' => 'Suggest an edit on GitHub',
+          '#url' => \Drupal\Core\Url::fromUri($github_url),
+          '#attributes' => ['target' => '_blank', 'rel' => 'noopener'],
+        ],
+      ];
+    }
   }
 
   // Appverse SPA redirects for software and app nodes.


### PR DESCRIPTION
The "Suggest an edit on GitHub" link hardcoded the ood-appverse repo and docs/ path, then appended the full raw.githubusercontent source URL — which produced a broken link (docs/https://raw...) for docs synced from the appverse-review repo. Transform the raw URL into its GitHub edit equivalent instead, so each doc links to its actual repo and path.

## Describe context / purpose for this PR

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
