### PR TITLE
Three changes to the admin "Manage Appverse Repos" view for reviewers

### DIFF
--- a/web/modules/custom/ood_software/css/appverse-hub.css
+++ b/web/modules/custom/ood_software/css/appverse-hub.css
@@ -344,8 +344,19 @@ header:has(> .appverse-hub-add-repo) {
   font-weight: 600;
   color: #c91235; /* appverse-red — brand link color */
   text-decoration: none;
+  /* Truncate a long owner name so it stays within the fixed owner track
+     instead of overflowing into the status column and colliding with the
+     badge. The envelope icon that follows keeps its space. */
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .appverse-hub-card__owner:hover { text-decoration: underline; }
+/* The email icon must not shrink when the name truncates. */
+.appverse-hub-card__cell--owner .appverse-hub-card__icon-btn {
+  flex-shrink: 0;
+}
 
 /* Icon buttons (links and form submits share one look). */
 .appverse-hub-card__icon-btn {

--- a/web/modules/custom/ood_software/ood_software.module
+++ b/web/modules/custom/ood_software/ood_software.module
@@ -2056,17 +2056,17 @@ function ood_software_views_pre_render(\Drupal\views\ViewExecutable $view): void
 /**
  * Implements hook_preprocess_views_view().
  *
- * Adds an "Add a repo" button to the top of the my_appverse hub (both the
- * user "My Apps" and admin "Manage repos" displays), linking to the existing
- * /appverse/add-repo submission form. No permission gate: 'submit appverse
- * repo' is granted to all authenticated users, and the page itself only needs
- * 'access content', so everyone who can reach the hub can submit. If submit is
- * ever restricted to specific roles, gate this on that permission then.
+ * Adds an "Add a repo" button to the user hub (page_user), linking to
+ * /appverse/add-repo. Not on the admin manage-repos display — adding a repo is
+ * a contributor action, not a reviewer one.
  *
  * @param array<string, mixed> $variables
  */
 function ood_software_preprocess_views_view(array &$variables): void {
   if (($variables['view'] ?? NULL) === NULL || $variables['view']->id() !== 'my_appverse') {
+    return;
+  }
+  if (($variables['view']->current_display ?? NULL) !== 'page_user') {
     return;
   }
   $button = [

--- a/web/sites/default/config/default/views.view.my_appverse.yml
+++ b/web/sites/default/config/default/views.view.my_appverse.yml
@@ -675,6 +675,7 @@ display:
         relationships: false
         filters: false
         filter_groups: false
+        header: false
         path: false
       relationships:
         reverse__node__field_appverse_repo:
@@ -687,6 +688,18 @@ display:
           entity_type: node
           plugin_id: entity_reverse
           required: false
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: false
+          content: '<p class="appverse-manage-intro">Reviewing a submission? Follow the <a href="/appverse-reviewer-checklist">Reviewer Checklist</a>.</p>'
+          tokenize: false
       display_extenders: {  }
       path: appverse/manage-repos
     cache_metadata:


### PR DESCRIPTION
- Add a persistent header linking the Reviewer Checklist, so reviewers can find it from the page where they work. Scoped to the page_admin display (gated to 'administer appverse content'); header:false in the display's defaults map is required for the display to use its own header instead of inheriting the empty default.
- Stop showing the "Add a repo" button on the admin manage view — adding a repo is a contributor action, out of place on the reviewer's manage-all view. It stays on the user hub (page_user).
- Truncate a long owner name so it stays within its grid track instead of overflowing into the status column and colliding with the badge.

## Describe context / purpose for this PR

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
