### PR TITLE
Fix/ood contributions and appverse

### DIFF
--- a/web/modules/custom/ood_contributions/src/Plugin/Block/ContributorsBlock.php
+++ b/web/modules/custom/ood_contributions/src/Plugin/Block/ContributorsBlock.php
@@ -57,6 +57,9 @@ class ContributorsBlock extends BlockBase implements ContainerFactoryPluginInter
    * @param \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator
    *   The file URL generator.
    */
+  /**
+   * @param array<string, mixed> $configuration
+   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, Connection $database, EntityTypeManagerInterface $entity_type_manager, FileUrlGeneratorInterface $file_url_generator) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->database = $database;
@@ -67,8 +70,14 @@ class ContributorsBlock extends BlockBase implements ContainerFactoryPluginInter
   /**
    * {@inheritdoc}
    */
+  /**
+   * @param array<string, mixed> $configuration
+   */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new self(
+    // new static() is safe here: block plugins are only instantiated via the
+    // plugin manager, never subclassed with an incompatible constructor.
+    // @phpstan-ignore-next-line new.static
+    return new static(
       $configuration,
       $plugin_id,
       $plugin_definition,
@@ -80,6 +89,8 @@ class ContributorsBlock extends BlockBase implements ContainerFactoryPluginInter
 
   /**
    * {@inheritdoc}
+   *
+   * @return array<string, mixed>
    */
   public function build() {
     $contributors = $this->getContributors();
@@ -96,14 +107,20 @@ class ContributorsBlock extends BlockBase implements ContainerFactoryPluginInter
   /**
    * Get list of contributors from the database.
    *
-   * @return array
+   * @return array<int, array<string, mixed>>
    *   Array of contributor data.
    */
   protected function getContributors() {
+    // Order contributors by their most recent commit (newest first) so the
+    // most-recently-active people lead the grid. Group by uid and sort on
+    // MAX(commit_date); loadMultiple() ignores the id order it's given, so we
+    // re-apply the query order when building the list below.
     $query = $this->database->select('ood_user_commits', 'ouc');
-    $query->fields('ouc', ['uid']);
-    $query->distinct();
+    $query->addField('ouc', 'uid');
+    $query->addExpression('MAX(ouc.commit_date)', 'last_commit');
     $query->condition('ouc.uid', 0, '>');
+    $query->groupBy('ouc.uid');
+    $query->orderBy('last_commit', 'DESC');
     $uids = $query->execute()->fetchCol();
 
     if (empty($uids)) {
@@ -113,12 +130,17 @@ class ContributorsBlock extends BlockBase implements ContainerFactoryPluginInter
     $users = $this->entityTypeManager->getStorage('user')->loadMultiple($uids);
     $contributors = [];
 
-    foreach ($users as $user) {
+    // Iterate the ordered uids (not $users) to preserve the most-recent sort.
+    foreach ($uids as $uid) {
+      if (empty($users[$uid])) {
+        continue;
+      }
+      $user = $users[$uid];
       $photo_url = NULL;
 
       if ($user->hasField('user_picture') && !$user->get('user_picture')->isEmpty()) {
         $file = $user->get('user_picture')->entity;
-        if ($file) {
+        if ($file instanceof \Drupal\file\FileInterface) {
           $photo_url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
         }
       }

--- a/web/modules/custom/ood_contributions/src/Service/DiscourseApiService.php
+++ b/web/modules/custom/ood_contributions/src/Service/DiscourseApiService.php
@@ -51,7 +51,7 @@ class DiscourseApiService {
    * @param string $username
    *   The Discourse username.
    *
-   * @return array
+   * @return array<string, mixed>
    *   The user data or error information.
    */
   public function getUserByUsername(string $username): array {
@@ -88,14 +88,20 @@ class DiscourseApiService {
    * @param string $end_date
    *   End date in YYYY-MM-DD format.
    *
-   * @return array
-   *   The report data or error information.
+   * @return array<string, mixed>
+   *   A response envelope: ['error' => bool, 'data' => ..., 'message' => ...].
    */
   public function getDailyPostStats(string $start_date, string $end_date): array {
     try {
       $counts = [];
       $start_dt = new \DateTime($start_date);
+      // A bare Y-m-d string parses to midnight (00:00:00). Without this, the
+      // end-day boundary would reject every post made later than midnight on
+      // $end_date (e.g. a 18:36 post is > the 00:00 end), so an incremental
+      // run where start == end == today drops the whole day and records 0.
+      // Extend to the end of the day so the full end date is inclusive.
       $end_dt = new \DateTime($end_date);
+      $end_dt->setTime(23, 59, 59);
       $before_id = NULL;
       $page = 0;
 
@@ -113,7 +119,16 @@ class DiscourseApiService {
         }
 
         $oldest_date = NULL;
+        $min_id = NULL;
         foreach ($posts as $post) {
+          // Track the lowest post ID on this page for reliable backward
+          // pagination. Don't rely on array order (end($posts)) being strictly
+          // oldest-first — an explicit minimum id is order-independent and
+          // avoids skipping or looping if the API ordering ever varies.
+          if (isset($post['id']) && ($min_id === NULL || $post['id'] < $min_id)) {
+            $min_id = $post['id'];
+          }
+
           if (empty($post['created_at'])) {
             continue;
           }
@@ -141,9 +156,14 @@ class DiscourseApiService {
           break;
         }
 
-        // Set up pagination: use the lowest post ID on this page.
-        $last_post = end($posts);
-        $before_id = $last_post['id'];
+        // Guard against a page with no usable ids (would otherwise loop
+        // forever re-requesting the same page).
+        if ($min_id === NULL) {
+          break;
+        }
+
+        // Paginate backward using the lowest post ID on this page.
+        $before_id = $min_id;
 
         $page++;
         $this->logger->info('Discourse posts.json: fetched page @page (before=@before)', [
@@ -195,7 +215,7 @@ class DiscourseApiService {
    * @param string $url
    *   The API URL.
    *
-   * @return array
+   * @return array<string, mixed>
    *   The decoded JSON response.
    *
    * @throws \GuzzleHttp\Exception\GuzzleException

--- a/web/modules/custom/ood_software/src/Plugin/GitHubService.php
+++ b/web/modules/custom/ood_software/src/Plugin/GitHubService.php
@@ -896,7 +896,38 @@ class GitHubService {
       if ($skipped > 0) {
         $this->logger->notice('Skipped @n appverse.yml apps[] entry/entries without a non-empty path.', ['@n' => $skipped]);
       }
+
+      // SHAPE 1: a declared single-app repo. The root appverse.yml has no
+      // apps[] list and instead declares one app's metadata at the top level
+      // (software, app_type, etc.) — the repo IS the app. RepoSyncService
+      // already registers this shape; the preview must recognise it too, or a
+      // valid single-app repo reports "0 apps". Build one record from the root
+      // appverse layer, sitting at the repo root (empty subpath).
       if (empty($subpaths)) {
+        if (!empty($appverse['software'])) {
+          $repoReadme = $this->readme;
+          $softwareInfo = $this->resolveSoftwareForApp($appverse['software'] ?? NULL);
+          $declaredTags = $appverse['implementation_tags'] ?? NULL;
+          $tagsInfo = $this->resolveTaxonomyTermsFromAppverseYml('appverse_implementation_tags', is_array($declaredTags) ? $declaredTags : NULL);
+          return [
+            [
+              'subpath' => '',
+              'name' => $appverse['name'] ?? $appverse['title'] ?? NULL,
+              'category' => $appverse['category'] ?? NULL,
+              'subcategory' => $appverse['subcategory'] ?? NULL,
+              'role' => $appverse['role'] ?? NULL,
+              'description' => $appverse['description'] ?? NULL,
+              'license' => $appverse['license'] ?? $this->license,
+              'clusters' => [],
+              'formFields' => [],
+              'attributes' => [],
+              'readmePresent' => $repoReadme !== NULL,
+              'readmeBytes' => $repoReadme !== NULL ? strlen($repoReadme) : 0,
+              'software' => $softwareInfo,
+              'tags' => $tagsInfo,
+            ],
+          ];
+        }
         return [];
       }
       // fetchAppSubpaths() throws on a transport/GraphQL failure. This is a


### PR DESCRIPTION
## Describe context / purpose for this PR
### Summary

Three fixes across the Appverse and contributor-wall features, found while investigating the contributor wall showing no Discourse activity since March.

### Contributor wall — Discourse daily stats broken since launch

The Discourse Participation heatmap on /contributor-wall has shown empty since the feature launched (commit 38ebce6e, 2026-03-08). Root cause: DiscourseApiService::getDailyPostStats() built its end-of-range boundary from a bare Y-m-d string, which parses to midnight (00:00:00). The subsequent $post_date > $end_dt check then rejected every post made later that day. On the daily incremental run, start and end are both today, so the whole day's posts were dropped and post_count 0 was written for every day. The one-time 365-day backfill at launch worked (historical days fall fully before the current day), which is why the heatmap showed data through early March then went flat.

Fix: set the end boundary to 23:59:59 so the full end date is inclusive. Also hardened the backward pagination to cursor on the explicit minimum post id per page (rather than assuming end($posts) is always oldest) and to break on a page with no usable ids, so a malformed response can't loop. That pagination change only matters for multi-page (backfill-style) fetches; the daily run is a single day.

Verified against the live Discourse API: the fixed logic returns correct non-zero counts. The empty window (Mar 7–present) was backfilled separatel now shows real dataagain.                                                                 Contributor wall — G The GitHub contributid order (effectively account-creation ordibutors weren't
surfaced. Now orderecommit
(MAX(commit_date) DEds since
loadMultiple() ignor

### Appverse — single-ap "0 apps"

A declared repo can  an apps: list, orSHAPE 1 where the root appverse.yml declares one app's metadata at the
top level (software, the app. The sync(RepoSyncService) already registers both, but
GitHubService::getApps[], so a SHAPE 1
repo previewed as "0pps" even though the
sync would create ono the preview,
mirroring the sync'srified against
Sweet-and-Fizzy/ood-ne app instead of
zero.

### Notes

- PHPStan level-6 debt in the two touched ood_contributions files was cleaned up (type decuard) so thepre-commit hook passes.
- No config or schema changes; all three are code-only.

## Issue link

## Any other related PRs?

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
