### PR TITLE
Acting-user permission model: pin access to feat/acting-user (#34)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "require": {
         "access/drupal_seamless_cilogon": "3.0.x-dev",
         "access/infrastructure_news": "1.0.x-dev",
-        "connectci/access": "feat/acting-user-dev",
+        "connectci/access": "3.0.x-dev",
         "connectci/asp-theme": "main-dev",
         "connectci/campus-champions-theme": "main-dev",
         "connectci/operations_cider": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "require": {
         "access/drupal_seamless_cilogon": "3.0.x-dev",
         "access/infrastructure_news": "1.0.x-dev",
-        "connectci/access": "3.0.x-dev",
+        "connectci/access": "feat/acting-user-dev",
         "connectci/asp-theme": "main-dev",
         "connectci/campus-champions-theme": "main-dev",
         "connectci/operations_cider": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -679,7 +679,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/access.git",
-                "reference": "f9bf4f768150ab2e0fa6e9f302c4edf1f9efbd29"
+                "reference": "51d254457019e8cab8778d9fd9da66710ed2a979"
             },
             "require": {
                 "firebase/php-jwt": "^6.0 || ^7.0",
@@ -701,7 +701,7 @@
                 "issues": "https://github.com/connectci-platform/access/issues",
                 "source": "https://github.com/connectci-platform/access"
             },
-            "time": "2026-08-01T00:27:19+00:00"
+            "time": "2026-08-01T15:02:13+00:00"
         },
         {
             "name": "connectci/asp-theme",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f725e6f5634e8e1f3f378b0b946e1f4",
+    "content-hash": "61b9e00f28de3b8c0651d6477932d44b",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -675,18 +675,17 @@
         },
         {
             "name": "connectci/access",
-            "version": "3.0.x-dev",
+            "version": "dev-feat/acting-user",
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/access.git",
-                "reference": "61b6882dfabc299ef539a0abff779bcc2c8fec6d"
+                "reference": "26f1e181be7bf8887fb0900f65e1e1602b7fa269"
             },
             "require": {
                 "firebase/php-jwt": "^6.0 || ^7.0",
                 "gioni06/gpt3-tokenizer": "^1.2",
                 "openai-php/client": "^0.10"
             },
-            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "GPL-2.0+"
@@ -702,7 +701,7 @@
                 "issues": "https://github.com/connectci-platform/access/issues",
                 "source": "https://github.com/connectci-platform/access"
             },
-            "time": "2026-07-28T03:26:02+00:00"
+            "time": "2026-07-31T23:49:01+00:00"
         },
         {
             "name": "connectci/asp-theme",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "61b9e00f28de3b8c0651d6477932d44b",
+    "content-hash": "5f725e6f5634e8e1f3f378b0b946e1f4",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -675,17 +675,18 @@
         },
         {
             "name": "connectci/access",
-            "version": "dev-feat/acting-user",
+            "version": "3.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/access.git",
-                "reference": "51d254457019e8cab8778d9fd9da66710ed2a979"
+                "reference": "ff188c7e892881f90448eaf24fa544be18244a88"
             },
             "require": {
                 "firebase/php-jwt": "^6.0 || ^7.0",
                 "gioni06/gpt3-tokenizer": "^1.2",
                 "openai-php/client": "^0.10"
             },
+            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "GPL-2.0+"
@@ -701,7 +702,7 @@
                 "issues": "https://github.com/connectci-platform/access/issues",
                 "source": "https://github.com/connectci-platform/access"
             },
-            "time": "2026-08-01T15:02:13+00:00"
+            "time": "2026-08-01T15:30:23+00:00"
         },
         {
             "name": "connectci/asp-theme",

--- a/composer.lock
+++ b/composer.lock
@@ -679,7 +679,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/access.git",
-                "reference": "26f1e181be7bf8887fb0900f65e1e1602b7fa269"
+                "reference": "f9bf4f768150ab2e0fa6e9f302c4edf1f9efbd29"
             },
             "require": {
                 "firebase/php-jwt": "^6.0 || ^7.0",
@@ -701,7 +701,7 @@
                 "issues": "https://github.com/connectci-platform/access/issues",
                 "source": "https://github.com/connectci-platform/access"
             },
-            "time": "2026-07-31T23:49:01+00:00"
+            "time": "2026-08-01T00:27:19+00:00"
         },
         {
             "name": "connectci/asp-theme",

--- a/web/sites/default/config/default/views.view.access_announcements.yml
+++ b/web/sites/default/config/default/views.view.access_announcements.yml
@@ -454,7 +454,7 @@ display:
         type: none
         options: {  }
       cache:
-        type: search_api_none
+        type: search_api_tag
         options: {  }
       empty: {  }
       sorts: {  }


### PR DESCRIPTION
## Describe context / purpose for this PR

Pins the `access` module to the `feat/acting-user` branch, which implements the acting-user permission model across the MCP-facing Drupal routes (ticket #34).

The core change is that MCP-gated requests now run as the acting user rather than the zero-permission service account. A single access gate (`ActingUserAccess`) resolves the `X-Acting-User` header and sets an `acting_user_uid` attribute, and a request event subscriber switches the Drupal current-user to that user via `AccountSwitcher` for the duration of the request, switching back on terminate. From that point Drupal's own entity access enforces the acting user's permissions, so the bare `save()`/`delete()` bypasses and the `mcp_bot` god-mode path are no longer needed.

On the events side this replaces the register/cancel bypasses with explicit entity-access assertions, adds an in-controller published gate to the event-detail read, and closes a uid=0 registration-state info leak. On the announcements side it moves create/update/delete and the own-drafts read off JSON:API onto a new custom `AnnouncementApiController` (`/api/1.0/announcements`) that enforces a per-group coordinator check plus node entity access, hardcodes new announcements to draft, and returns tags as english names. The two duplicate access services were consolidated into one.

Verified end to end on this MultiDev as a real acting user (create draft with tags, read back, summary-only update preserving the body, delete). Drupal kernel tests cover the switch lifecycle, the write/read authorization boundaries, the draft lock, per-user scoping, and tag handling.

Note on sequencing: this deploys the Drupal endpoints but does not slim the `mcp_bot` role. `mcp_bot`'s god-mode permissions must stay until the announcements MCP server is repointed to the new endpoints in prod, otherwise the old JSON:API path breaks. Slimming `mcp_bot` is a separate follow-up deployed after the MCP server cuts over.

## Issue link

#34

## Any other related PRs?

access_mcp: announcements server repointed to /api/1.0/announcements[...] (branch feat/acting-user-announcements). mcp_bot role slim is a separate follow-up.

## Link to MultiDev instance

http://md-actuser-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
