### PR TITLE
Md 2789 2

### DIFF
--- a/.github/actions/dingorunner/entrypoint.sh
+++ b/.github/actions/dingorunner/entrypoint.sh
@@ -148,7 +148,14 @@ then
   echo 'Add new files'
   git add .
   echo 'Commit changes'
-  git commit -m "$message"
+  # A config/code-only branch can produce no build-artifact changes, in which
+  # case there is nothing to commit. Skip the commit rather than let git's
+  # non-zero exit abort the deploy (which would leave the multidev uncreated).
+  if git diff --cached --quiet; then
+    echo 'No build changes to commit; pushing existing branch state.'
+  else
+    git commit -m "$message"
+  fi
   echo 'status'
   git status
   echo 'push'

--- a/.github/workflows/backupdb.yml
+++ b/.github/workflows/backupdb.yml
@@ -48,10 +48,10 @@ jobs:
           ddev drush cim -y
           ddev drush pmu drupal_seamless_cilogon cilogon_auth -y 2>/dev/null || true
           ddev drush cr
-          ddev drush user-create authenticated_test_user --mail="authenticated@amptesting.com" --password="6%l7iF}6(4tI"
-          ddev drush user-create administrator_test_user --mail="administrator@amptesting.com" --password="b8QW]X9h7#5n"
-          ddev drush user-add-role "administrator" administrator_test_user
           ddev drush sql-query "TRUNCATE TABLE node__field_domain_source"
+          # authenticated_test_user / administrator_test_user are created by
+          # amp_dev's install hook (amp_dev_install_create_test_users) with a
+          # name + organization, so they are no longer created bare here.
           ddev drush en amp_dev
           ddev drush pmu amp_dev
           ddev drush pmu symfony_mailer

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "connectci/asp-theme": "main-dev",
         "connectci/campus-champions-theme": "main-dev",
         "connectci/operations_cider": "dev-main",
-        "connectci/webform_submission_search_api": "main-dev",
+        "connectci/access": "3.0.x-dev",
         "composer/installers": "^2.3.0",
         "cweagans/composer-patches": "^2.0",
         "drupal/access_by_ref": "^4.0.0",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "connectci/asp-theme": "main-dev",
         "connectci/campus-champions-theme": "main-dev",
         "connectci/operations_cider": "dev-main",
-        "connectci/access": "3.0.x-dev",
+        "connectci/webform_submission_search_api": "main-dev",
         "composer/installers": "^2.3.0",
         "cweagans/composer-patches": "^2.0",
         "drupal/access_by_ref": "^4.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f725e6f5634e8e1f3f378b0b946e1f4",
+    "content-hash": "f86941ffd70783516cf4447b580da484",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -792,39 +792,6 @@
                 "source": "https://github.com/connectci-platform/operations_cider"
             },
             "time": "2026-07-13T14:40:10+00:00"
-        },
-        {
-            "name": "connectci/webform_submission_search_api",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/connectci-platform/webform_submission_search_api.git",
-                "reference": "a646925bf3c798ba92c3bcfe9624a6654305be1f"
-            },
-            "require": {
-                "drupal/search_api": "^1.3",
-                "drupal/webform": "^6"
-            },
-            "default-branch": true,
-            "type": "drupal-custom-module",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andrew Pasquale",
-                    "email": "andrew@elytra.net"
-                }
-            ],
-            "description": "Index fields from Webform Submissions for Search API",
-            "keywords": [
-                "Drupal"
-            ],
-            "support": {
-                "issues": "https://github.com/connectci-platform/webform_submission_search_api/issues",
-                "source": "https://github.com/connectci-platform/webform_submission_search_api"
-            },
-            "time": "2026-07-13T01:29:17+00:00"
         },
         {
             "name": "consolidation/annotated-command",
@@ -24459,7 +24426,6 @@
         "connectci/asp-theme": 20,
         "connectci/campus-champions-theme": 20,
         "connectci/operations_cider": 20,
-        "connectci/webform_submission_search_api": 20,
         "drupal/auditfiles": 10,
         "drupal/crawler_rate_limit": 10,
         "drupal/datalayer": 5,

--- a/composer.lock
+++ b/composer.lock
@@ -18996,7 +18996,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/amp_dev.git",
-                "reference": "5d4a8ee042156ef686927f0d11b39656645a2d6b"
+                "reference": "93db315613ef120ba34d0a172061a7252c844138"
             },
             "default-branch": true,
             "type": "drupal-custom-module",
@@ -19008,7 +19008,7 @@
             "keywords": [
                 "Drupal"
             ],
-            "time": "2026-08-05T12:48:42+00:00"
+            "time": "2026-08-05T19:04:31+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/composer.lock
+++ b/composer.lock
@@ -18996,7 +18996,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/amp_dev.git",
-                "reference": "5e6c28d61410d1dea67ec84aacaab9eebc004bba"
+                "reference": "ab23239592684b448e9ed9505041be0a87d89905"
             },
             "default-branch": true,
             "type": "drupal-custom-module",
@@ -19008,7 +19008,7 @@
             "keywords": [
                 "Drupal"
             ],
-            "time": "2026-07-21T14:38:50+00:00"
+            "time": "2026-08-05T01:59:09+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -24485,5 +24485,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -18996,7 +18996,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/amp_dev.git",
-                "reference": "ab23239592684b448e9ed9505041be0a87d89905"
+                "reference": "5d4a8ee042156ef686927f0d11b39656645a2d6b"
             },
             "default-branch": true,
             "type": "drupal-custom-module",
@@ -19008,7 +19008,7 @@
             "keywords": [
                 "Drupal"
             ],
-            "time": "2026-08-05T01:59:09+00:00"
+            "time": "2026-08-05T12:48:42+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f86941ffd70783516cf4447b580da484",
+    "content-hash": "5f725e6f5634e8e1f3f378b0b946e1f4",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -792,6 +792,39 @@
                 "source": "https://github.com/connectci-platform/operations_cider"
             },
             "time": "2026-07-13T14:40:10+00:00"
+        },
+        {
+            "name": "connectci/webform_submission_search_api",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/connectci-platform/webform_submission_search_api.git",
+                "reference": "a646925bf3c798ba92c3bcfe9624a6654305be1f"
+            },
+            "require": {
+                "drupal/search_api": "^1.3",
+                "drupal/webform": "^6"
+            },
+            "default-branch": true,
+            "type": "drupal-custom-module",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andrew Pasquale",
+                    "email": "andrew@elytra.net"
+                }
+            ],
+            "description": "Index fields from Webform Submissions for Search API",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "issues": "https://github.com/connectci-platform/webform_submission_search_api/issues",
+                "source": "https://github.com/connectci-platform/webform_submission_search_api"
+            },
+            "time": "2026-07-13T01:29:17+00:00"
         },
         {
             "name": "consolidation/annotated-command",
@@ -24426,6 +24459,7 @@
         "connectci/asp-theme": 20,
         "connectci/campus-champions-theme": 20,
         "connectci/operations_cider": 20,
+        "connectci/webform_submission_search_api": 20,
         "drupal/auditfiles": 10,
         "drupal/crawler_rate_limit": 10,
         "drupal/datalayer": 5,

--- a/robo/assets/md/md-2789-2
+++ b/robo/assets/md/md-2789-2
@@ -1,0 +1,1 @@
+campuschampions_cyberinfrastructure_org

--- a/tests/cypress/cypress/e2e/accessmatch1/webforms/auth-request-join-champions.cy.js
+++ b/tests/cypress/cypress/e2e/accessmatch1/webforms/auth-request-join-champions.cy.js
@@ -20,8 +20,12 @@ describe('Authenticated user requests to join campus champions', () => {
       // an organization on their account (set in amp_dev), so it is prefilled
       // and no selection is needed. Carnegie/Institution stay hidden (they only
       // show for "Other"), which is why the old carnegie_classification entry is
-      // gone.
-      cy.get('input[name="field_access_organization"]').should('not.have.value', '');
+      // gone. Assert the value is a resolved entity reference ("Label (nid)"),
+      // not merely non-empty — a bare not-empty check would pass for a stale or
+      // unresolved value.
+      cy.get('input[name="field_access_organization"]')
+        .invoke('val')
+        .should('match', /\(\d+\)\s*$/);
       cy.get('#edit-submit').click();
       cy.contains('Your application to the Campus Champions program was successfully submitted. You should hear from us soon. Thank you!')
     });

--- a/tests/cypress/cypress/e2e/accessmatch1/webforms/auth-request-join-champions.cy.js
+++ b/tests/cypress/cypress/e2e/accessmatch1/webforms/auth-request-join-champions.cy.js
@@ -16,7 +16,14 @@ describe('Authenticated user requests to join campus champions', () => {
       cy.get('#edit-study-field').type('math');
       cy.get('#edit-mentor-name').type('Pecan Pie (201)');
       cy.get('#edit-mentor-email').type('pecan@pie.com');
-      cy.get('#edit-carnegie-classification').type('Academy College');
+      // Select an ACCESS Organization (now required). The test fixture user has
+      // no organization on their account, so select one explicitly rather than
+      // relying on the logged-in prefill. Choosing a real org keeps the Carnegie
+      // and Institution fields hidden (they only show for "Other"), which is why
+      // the old carnegie_classification entry is gone.
+      cy.get('input[name="field_access_organization"]').clear().type('Arkansas for Medical');
+      cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+        .contains('University of Arkansas for Medical Sciences').click();
       cy.get('#edit-submit').click();
       cy.contains('Your application to the Campus Champions program was successfully submitted. You should hear from us soon. Thank you!')
     });

--- a/tests/cypress/cypress/e2e/accessmatch1/webforms/auth-request-join-champions.cy.js
+++ b/tests/cypress/cypress/e2e/accessmatch1/webforms/auth-request-join-champions.cy.js
@@ -16,14 +16,12 @@ describe('Authenticated user requests to join campus champions', () => {
       cy.get('#edit-study-field').type('math');
       cy.get('#edit-mentor-name').type('Pecan Pie (201)');
       cy.get('#edit-mentor-email').type('pecan@pie.com');
-      // Select an ACCESS Organization (now required). The test fixture user has
-      // no organization on their account, so select one explicitly rather than
-      // relying on the logged-in prefill. Choosing a real org keeps the Carnegie
-      // and Institution fields hidden (they only show for "Other"), which is why
-      // the old carnegie_classification entry is gone.
-      cy.get('input[name="field_access_organization"]').clear().type('Arkansas for Medical');
-      cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
-        .contains('University of Arkansas for Medical Sciences').click();
+      // The ACCESS Organization is required. This authenticated fixture user has
+      // an organization on their account (set in amp_dev), so it is prefilled
+      // and no selection is needed. Carnegie/Institution stay hidden (they only
+      // show for "Other"), which is why the old carnegie_classification entry is
+      // gone.
+      cy.get('input[name="field_access_organization"]').should('not.have.value', '');
       cy.get('#edit-submit').click();
       cy.contains('Your application to the Campus Champions program was successfully submitted. You should hear from us soon. Thank you!')
     });

--- a/tests/cypress/cypress/e2e/accessmatch2/misc/verify-test-users.cy.js
+++ b/tests/cypress/cypress/e2e/accessmatch2/misc/verify-test-users.cy.js
@@ -3,13 +3,15 @@
  */
 describe('Verify test users can login', () => {
   it('should login', () => {
+    // The profile page shows the display name (first + last), which these
+    // fixture users now have, rather than the raw username.
     cy.loginAs('authenticated@amptesting.com', '6%l7iF}6(4tI');
     cy.visit('/user/authenticatedtestuser')
-      .contains('authenticated_test_user');
+      .contains('Authenticated Testuser');
     cy.task('log', 'logged in as authenticated_test_user');
     cy.loginAs('administrator@amptesting.com', 'b8QW]X9h7#5n');
     cy.visit('/user/administratortestuser')
-      .contains('administrator_test_user');
+      .contains('Administrator Testuser');
     cy.task('log', 'logged in as administrator_test_user');
   });
 });

--- a/tests/cypress/cypress/e2e/campuschampions/access-organization-field.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/access-organization-field.cy.js
@@ -20,9 +20,11 @@ describe("ACCESS Organization field - Campus Champions", () => {
     });
 
     it("Should show/hide Institution field when Other is selected on edit form", () => {
-      // Login as authenticated user
-      cy.loginUser('authenticated@amptesting.com', '6%l7iF}6(4tI');
-      
+      // Log in as an administrator: the org field is read-only for a non-admin
+      // who already has an organization (the D8-2789 change-institution guard),
+      // so editing it to 'Other' to test the Institution reveal requires admin.
+      cy.loginUser('administrator@amptesting.com', 'b8QW]X9h7#5n');
+
       // Visit user edit page
       cy.visit('/user/edit');
       

--- a/tests/cypress/cypress/e2e/campuschampions/access-organization-field.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/access-organization-field.cy.js
@@ -19,61 +19,46 @@ describe("ACCESS Organization field - Campus Champions", () => {
         .should('have.attr', 'type', 'text');
     });
 
-    it("Should show/hide Institution field when Other is selected on edit form", () => {
+    it("Should reveal the Institution field when Other is selected on edit form", () => {
       // Log in as an administrator: the org field is read-only for a non-admin
       // who already has an organization (the D8-2789 change-institution guard),
       // so editing it to 'Other' to test the Institution reveal requires admin.
       cy.loginUser('administrator@amptesting.com', 'b8QW]X9h7#5n');
-
-      // Visit user edit page
       cy.visit('/user/edit');
-      
-      // Test Other functionality
-      cy.get('#edit-field-access-organization-0-target-id')
-        .should('exist')
-        .should('be.visible')
-        .then(($input) => {
-          const currentValue = $input.val();
-          
-          // Clear and type 'Other'
-          cy.expectAjax('orgAjax', '**/entity_reference_autocomplete/**');
-          cy.get('#edit-field-access-organization-0-target-id')
-            .clear()
-            .type('Other');
-          cy.waitForAjax('orgAjax');
 
-          // Click 'Other' if the dropdown rendered, else accept the typed value.
-          cy.get('body').then(($body) => {
-            if ($body.find('.ui-autocomplete:visible').length > 0) {
-              cy.get('.ui-autocomplete li').contains('Other').click();
-            } else {
-              cy.log('No autocomplete suggestions appeared for Other');
-              cy.get('#edit-field-access-organization-0-target-id').type('{enter}');
-            }
-          });
-          
-          // Check if Institution field becomes visible
-          cy.get('body').then(($body) => {
-            const institutionField = $body.find('input[name*="institution"], textarea[name*="institution"]');
-            if (institutionField.length > 0) {
-              cy.get('input[name*="institution"], textarea[name*="institution"]')
-                .should('be.visible')
-                .should('not.be.disabled')
-                .clear()
-                .type('Test Edit University Campus Champions')
-                .should('have.value', 'Test Edit University Campus Champions');
-            } else {
-              cy.log('Institution field not found on user edit form');
-            }
-          });
-          
-          // Revert back to original value if it exists
-          if (currentValue) {
-            cy.get('#edit-field-access-organization-0-target-id')
-              .clear()
-              .type(currentValue);
-          }
-        });
+      // Institution is hidden until the org resolves to "Other" (node 3695) —
+      // the #states condition is field_access_organization target_id == 3695.
+      cy.get('input[name="field_institution[0][value]"]').should('not.be.visible');
+
+      // Select the "Other" organization from the autocomplete so the field's
+      // value is the real entity reference (3695), which drives the #states
+      // reveal. Assert we actually picked it rather than accepting typed text.
+      cy.get('#edit-field-access-organization-0-target-id').clear().type('Other');
+      cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+        .contains(/^Other/).click();
+      cy.get('#edit-field-access-organization-0-target-id')
+        .should('have.value', 'Other (3695)');
+
+      // The Institution field must now be revealed and editable — a hard
+      // assertion, not a conditional that passes when the field is absent.
+      cy.get('input[name="field_institution[0][value]"]')
+        .should('be.visible')
+        .should('not.be.disabled')
+        .clear()
+        .type('Test Edit University Campus Champions')
+        .should('have.value', 'Test Edit University Campus Champions');
+    });
+
+    it("Should keep the organization field read-only for a non-admin who has one", () => {
+      // The D8-2789 change-institution guard makes field_access_organization
+      // read-only/disabled on the campus champions domain for a non-admin who
+      // already has an organization. authenticated_test_user has one (fixture),
+      // so the field must be locked for them.
+      cy.loginUser('authenticated@amptesting.com', '6%l7iF}6(4tI');
+      cy.visit('/user/edit');
+      cy.get('#edit-field-access-organization-0-target-id').should('exist');
+      cy.get('#edit-field-access-organization-0-target-id').should('have.attr', 'readonly', 'readonly');
+      cy.get('#edit-field-access-organization-0-target-id').should('be.disabled');
     });
   });
 });

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-applications-admin.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-applications-admin.cy.js
@@ -36,7 +36,9 @@ describe('Campus Champions Applications Admin', () => {
     cy.get('#edit-champion-user-type-user-champion').check();
     cy.get('input[name="supervisor_name"]').type('Test Supervisor');
     cy.get('input[name="supervisor_email"]').type('supervisor@test.com');
-    cy.get('input[name="carnegie_classification"]').type('167394');
+    cy.get('input[name="field_access_organization"]').type('Arkansas for Medical');
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+      .contains('University of Arkansas for Medical Sciences').click();
     cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit').click();
     cy.contains('Campus Champions Application Submitted', { timeout: 30000 });
   });

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-applications-search.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-applications-search.cy.js
@@ -1,0 +1,114 @@
+/**
+ * Campus Champions Applications Search Filter (D8-2789)
+ *
+ * The /cc-applications admin view has a single exposed "Search" box that
+ * matches a term against the applicant first name, last name, or email at
+ * once. This lets an admin find an applicant directly instead of paging or
+ * using the duplicate-names toggle.
+ *
+ * The filter is a custom views handler (campuschampions_applicant_search)
+ * that ORs the term across the configured submission elements in one subquery.
+ *
+ * Access requires: administrator OR campuschampionsadmin role.
+ * Runs on the campus champions domain (CYPRESS_BASE_URL=campuschampions).
+ *
+ * Test users:
+ * - pecan@pie.org / Pecan - has campuschampionsadmin role
+ */
+describe('Campus Champions Applications Search', () => {
+  // Two distinct applicants so search can prove it narrows to one and excludes
+  // the other. Names/emails are deliberately unusual to avoid collisions with
+  // seeded fixture data ("User", "Test", etc.).
+  const alpha = {
+    username: 'cypress-search-zollarge',
+    email: 'zolarge-search@no-reply.com',
+    first: 'Zolarge',
+    last: 'Quibblesnout',
+  };
+  const beta = {
+    username: 'cypress-search-vexmoot',
+    email: 'vexmoot-search@no-reply.com',
+    first: 'Vexmoot',
+    last: 'Thrangle',
+  };
+
+  // Submit the join form to create one application.
+  const seedApplication = (person) => {
+    cy.visit('/form/join-campus-champions');
+    cy.get('#edit-letter-of-collaboration-upload')
+      .selectFile('cypress/files/northern-lights.pdf');
+    cy.contains('Remove', { timeout: 10000 });
+    cy.get('input[name="username"]').type(person.username);
+    cy.get('input[name="user_first_name"]').type(person.first);
+    cy.get('input[name="user_last_name"]').type(person.last);
+    cy.get('input[name="user_email"]').type(person.email);
+    cy.get('#edit-champion-user-type-user-champion').check();
+    cy.get('input[name="supervisor_name"]').type('Test Supervisor');
+    cy.get('input[name="supervisor_email"]').type('supervisor@test.com');
+    cy.get('input[name="field_access_organization"]').type('Arkansas for Medical');
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+      .contains('University of Arkansas for Medical Sciences').click();
+    cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit').click();
+    cy.contains('Campus Champions Application Submitted', { timeout: 30000 });
+  };
+
+  before(() => {
+    // Clean up any leftovers from a prior run, then seed both applicants.
+    cy.exec(`ddev drush user:cancel --delete-content -y ${alpha.username}`, { failOnNonZeroExit: false });
+    cy.exec(`ddev drush user:cancel --delete-content -y ${beta.username}`, { failOnNonZeroExit: false });
+    seedApplication(alpha);
+    seedApplication(beta);
+  });
+
+  after(() => {
+    cy.exec(`ddev drush user:cancel --delete-content -y ${alpha.username}`, { failOnNonZeroExit: false });
+    cy.exec(`ddev drush user:cancel --delete-content -y ${beta.username}`, { failOnNonZeroExit: false });
+  });
+
+  beforeEach(() => {
+    cy.loginUser('pecan@pie.org', 'Pecan');
+  });
+
+  it('renders the search box in the exposed form', () => {
+    cy.visit('/cc-applications');
+    cy.get('input[name="search"]').should('exist').and('be.visible');
+  });
+
+  it('finds an applicant by last name and excludes non-matches', () => {
+    cy.visit(`/cc-applications?search=${alpha.last}`);
+    cy.get('tbody').should('contain', alpha.last);
+    cy.get('tbody').should('not.contain', beta.last);
+  });
+
+  it('finds an applicant by first name', () => {
+    cy.visit(`/cc-applications?search=${beta.first}`);
+    cy.get('tbody').should('contain', beta.last);
+    cy.get('tbody').should('not.contain', alpha.last);
+  });
+
+  it('finds an applicant by email fragment', () => {
+    // Search a distinctive slice of the email local-part.
+    cy.visit('/cc-applications?search=vexmoot-search');
+    cy.get('tbody').should('contain', beta.last);
+    cy.get('tbody').should('not.contain', alpha.last);
+  });
+
+  it('is case-insensitive', () => {
+    cy.visit(`/cc-applications?search=${alpha.last.toLowerCase()}`);
+    cy.get('tbody').should('contain', alpha.last);
+  });
+
+  it('returns no rows for a term that matches nobody', () => {
+    cy.visit('/cc-applications?search=zzqx_nobody_9999');
+    cy.get('tbody').should('not.contain', alpha.last);
+    cy.get('tbody').should('not.contain', beta.last);
+  });
+
+  it('returns the full result set when the search box is empty', () => {
+    // With no term, both seeded applicants are present (subject to the status
+    // filter default, which includes "new" — freshly seeded apps are new).
+    cy.visit('/cc-applications');
+    cy.get('tbody').should('contain', alpha.last);
+    cy.get('tbody').should('contain', beta.last);
+  });
+});

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-applications-search.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-applications-search.cy.js
@@ -100,8 +100,12 @@ describe('Campus Champions Applications Search', () => {
 
   it('returns no rows for a term that matches nobody', () => {
     cy.visit('/cc-applications?search=zzqx_nobody_9999');
-    cy.get('tbody').should('not.contain', alpha.last);
-    cy.get('tbody').should('not.contain', beta.last);
+    // A term matching nobody yields an empty result set — the view renders no
+    // results table at all, so assert against the page body rather than tbody
+    // (which does not exist when there are zero rows).
+    cy.get('.view-cc-applications, .views-element-container, main').should('exist');
+    cy.get('body').should('not.contain', alpha.last);
+    cy.get('body').should('not.contain', beta.last);
   });
 
   it('returns the full result set when the search box is empty', () => {

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-approve-action.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-approve-action.cy.js
@@ -63,7 +63,11 @@ describe('Campus Champions Approve Action', () => {
       cy.get('input[name="mentor_email"]').type('pecan@pie.org');
     }
 
-    cy.get('input[name="carnegie_classification"]').type(carnegieCode);
+    // Select the ACCESS Organization (required). A real org derives the
+    // Carnegie code server-side, so the Carnegie field stays hidden.
+    cy.get('input[name="field_access_organization"]').type('Arkansas for Medical');
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+      .contains('University of Arkansas for Medical Sciences').click();
 
     cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
       .contains('Submit').click();

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-decline-action.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-decline-action.cy.js
@@ -53,7 +53,9 @@ describe('Campus Champions Decline Action', () => {
       cy.get('input[name="mentor_email"]').type('pecan@pie.org');
     }
 
-    cy.get('input[name="carnegie_classification"]').type(carnegieCode);
+    cy.get('input[name="field_access_organization"]').type('Arkansas for Medical');
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+      .contains('University of Arkansas for Medical Sciences').click();
 
     cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
       .contains('Submit').click();

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-email-notifications.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-email-notifications.cy.js
@@ -36,7 +36,9 @@ describe('Campus Champions Email Notifications', () => {
       cy.get('#edit-champion-user-type-user-champion').check();
       cy.get('input[name="supervisor_name"]').type('Dr. Email Supervisor');
       cy.get('input[name="supervisor_email"]').type('email-supervisor@no-reply.com');
-      cy.get('input[name="carnegie_classification"]').type('166683');
+      cy.get('input[name="field_access_organization"]').type('Arkansas for Medical');
+      cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+        .contains('University of Arkansas for Medical Sciences').click();
 
       // Submit the form
       cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
@@ -48,10 +50,10 @@ describe('Campus Champions Email Notifications', () => {
       // Wait for and verify the welcome email
       cy.waitForEmail({
         to: testEmail,
-        subject: 'Welcome to the Campus Champions Portal'
+        subject: 'Welcome to the Campus Champions Portal!'
       }).then((message) => {
         cy.assertEmailContent(message, {
-          subject: 'Welcome to the Campus Champions Portal',
+          subject: 'Welcome to the Campus Champions Portal!',
           to: testEmail,
           htmlContains: [
             'Campus Champions',
@@ -83,7 +85,9 @@ describe('Campus Champions Email Notifications', () => {
       cy.get('#edit-champion-user-type-user-champion').check();
       cy.get('input[name="supervisor_name"]').type('Dr. Approval Supervisor');
       cy.get('input[name="supervisor_email"]').type('approval-supervisor@no-reply.com');
-      cy.get('input[name="carnegie_classification"]').type('166683');
+      cy.get('input[name="field_access_organization"]').type('Arkansas for Medical');
+      cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+        .contains('University of Arkansas for Medical Sciences').click();
 
       cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
         .contains('Submit').click();
@@ -149,7 +153,9 @@ describe('Campus Champions Email Notifications', () => {
       cy.get('#edit-champion-user-type-user-champion').check();
       cy.get('input[name="supervisor_name"]').type('Dr. Link Supervisor');
       cy.get('input[name="supervisor_email"]').type('link-supervisor@no-reply.com');
-      cy.get('input[name="carnegie_classification"]').type('166683');
+      cy.get('input[name="field_access_organization"]').type('Arkansas for Medical');
+      cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+        .contains('University of Arkansas for Medical Sciences').click();
 
       cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
         .contains('Submit').click();
@@ -159,7 +165,7 @@ describe('Campus Champions Email Notifications', () => {
       // Verify the email contains the password reset link
       cy.waitForEmail({
         to: linkTestEmail,
-        subject: 'Welcome'
+        subject: 'Welcome to the Campus Champions Portal!'
       }).then((message) => {
         cy.getMailpitMessage(message.ID).then((fullMessage) => {
           const html = fullMessage.HTML || '';

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form-carnegie.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form-carnegie.cy.js
@@ -1,186 +1,58 @@
 /**
- * Join Campus Champions Form - Carnegie Code Integration Tests
+ * Join Campus Champions Form - Institution / Carnegie type-ahead
  *
- * Tests the Carnegie classification code field integration in the
- * Join Campus Champions webform, including autocomplete functionality
- * and validation.
+ * With the ACCESS Organization field as the primary input, the Carnegie code
+ * is derived from the selected organization. The manual institution + Carnegie
+ * entry only appears in the "Other" flow, where the institution name is a
+ * type-ahead against the Carnegie institution list that fills the code on
+ * selection. These tests cover that type-ahead behavior in its current home.
  *
- * Note: The existing campuschampions-join-form.cy.js tests the full
- * form submission flow. These tests focus specifically on the Carnegie
- * code field behavior.
+ * MSI/HBCU/HSI classification logic is covered by
+ * campuschampions-msi-classification.cy.js and
+ * campuschampions-carnegie-validation.cy.js. The org-field reveal itself is
+ * covered by campuschampions-join-form-organization.cy.js.
  */
-describe('Join Campus Champions Form - Carnegie Code Integration', () => {
+describe('Join Campus Champions Form - Institution type-ahead (Other flow)', () => {
 
-  // Known valid Carnegie codes from 2025 data
-  const validCodes = {
-    alabamaAM: {
-      code: '100654',
-      name: 'Alabama A & M University'
-    },
-    mit: {
-      code: '166683',
-      name: 'Massachusetts Institute of Technology'
-    },
-    stanford: {
-      code: '243744',
-      name: 'Stanford University'
-    },
-    utep: {
-      code: '199193',
-      name: 'University of Texas at El Paso'
-    }
+  const chooseOther = () => {
+    cy.get('input[name="field_access_organization"]').type('Other');
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 }).contains(/^Other/).click();
   };
 
   beforeEach(() => {
     cy.visit('/form/join-campus-champions');
+    chooseOther();
   });
 
-  describe('Carnegie Code Field Display', () => {
-    it('should display Carnegie classification field on join form', () => {
-      cy.get('input[name="carnegie_classification"]').should('exist');
-      cy.get('input[name="carnegie_classification"]').should('be.visible');
-    });
-
-    it('should have autocomplete enabled for Carnegie field', () => {
-      // The field should have autocomplete attributes
-      cy.get('input[name="carnegie_classification"]')
-        .should('have.attr', 'data-drupal-selector');
-    });
+  it('shows institution suggestions when typing an institution name', () => {
+    cy.get('input[name="institution_name"]').type('Alabama A');
+    cy.get('.ui-autocomplete', { timeout: 10000 }).should('be.visible');
+    cy.get('.ui-autocomplete .ui-menu-item').should('have.length.at.least', 1);
   });
 
-  describe('Carnegie Code Autocomplete', () => {
-    it('should show autocomplete suggestions when typing institution name', () => {
-      cy.get('input[name="carnegie_classification"]').type('Alabama');
-
-      // Wait for autocomplete to appear
-      cy.get('.ui-autocomplete', { timeout: 10000 }).should('be.visible');
-      cy.get('.ui-autocomplete li').should('have.length.at.least', 1);
-    });
-
-    it('should show Alabama A & M University in autocomplete results', () => {
-      cy.get('input[name="carnegie_classification"]').type('Alabama A');
-
-      cy.get('.ui-autocomplete', { timeout: 10000 }).should('be.visible');
-      cy.contains('Alabama A & M University').should('be.visible');
-    });
-
-    it('should populate field when autocomplete option is selected', () => {
-      cy.get('input[name="carnegie_classification"]').type('Massachusetts Inst');
-
-      cy.get('.ui-autocomplete', { timeout: 10000 }).should('be.visible');
-      cy.contains('Massachusetts Institute of Technology').click();
-
-      // Field should now contain the selected code
-      cy.get('input[name="carnegie_classification"]')
-        .should('have.value', validCodes.mit.code);
-    });
-
-    it('should allow entering Carnegie code directly without autocomplete', () => {
-      // The autocomplete only works with institution names, not codes
-      // Users can still enter a valid code directly
-      cy.get('input[name="carnegie_classification"]').type('166683');
-      cy.get('input[name="carnegie_classification"]').should('have.value', '166683');
-    });
-
-    it('should filter results as user types more characters', () => {
-      // Type partial name
-      cy.get('input[name="carnegie_classification"]').type('Univ');
-      cy.get('.ui-autocomplete', { timeout: 10000 }).should('be.visible');
-
-      // Get initial count
-      cy.get('.ui-autocomplete li').then($items => {
-        const initialCount = $items.length;
-
-        // Clear and type more specific
-        cy.get('input[name="carnegie_classification"]').clear().type('University of Texas');
-        cy.get('.ui-autocomplete', { timeout: 10000 }).should('be.visible');
-
-        // Results should be filtered
-        cy.get('.ui-autocomplete li').should('have.length.at.least', 1);
-      });
-    });
+  it('fills the Carnegie code when an institution is selected', () => {
+    cy.get('input[name="institution_name"]').type('Massachusetts Inst');
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+      .contains('Massachusetts Institute of Technology').click();
+    cy.get('input[name="carnegie_classification"]').should('have.value', '166683');
   });
 
-  describe('Carnegie Code in Form Submission', () => {
-    it('should accept valid Carnegie code in form submission', () => {
-      const timestamp = Date.now();
-
-      // Fill required fields
-      cy.get('#edit-letter-of-collaboration-upload')
-        .selectFile('cypress/files/northern-lights.pdf');
-
-      // Wait for file upload to complete (filename appears with possible numeric suffix)
-      cy.contains(/northern-lights.*\.pdf/, { timeout: 10000 }).should('be.visible');
-
-      cy.get('input[name="username"]').type('carnegie-test-' + timestamp);
-      cy.get('input[name="user_first_name"]').type('Carnegie');
-      cy.get('input[name="user_last_name"]').type('Test');
-      cy.get('input[name="user_email"]').type('carnegie-test-' + timestamp + '@no-reply.com');
-      cy.get('#edit-champion-user-type-user-champion').check();
-      cy.get('input[name="supervisor_name"]').type('Dr. Supervisor');
-      cy.get('input[name="supervisor_email"]').type('supervisor@no-reply.com');
-
-      // Enter valid Carnegie code
-      cy.get('input[name="carnegie_classification"]').type(validCodes.mit.code);
-
-      // Submit form
-      cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
-        .contains('Submit').click();
-
-      // Should succeed
-      cy.contains('Campus Champions Application Submitted');
-    });
-
-    it('should allow form submission without Carnegie code for non-academic', () => {
-      const timestamp = Date.now();
-
-      // Fill required fields but leave Carnegie code empty
-      cy.get('#edit-letter-of-collaboration-upload')
-        .selectFile('cypress/files/northern-lights.pdf');
-
-      cy.get('input[name="username"]').type('nocarnegie-test-' + timestamp);
-      cy.get('input[name="user_first_name"]').type('NoCarnegie');
-      cy.get('input[name="user_last_name"]').type('Test');
-      cy.get('input[name="user_email"]').type('nocarnegie-test-' + timestamp + '@no-reply.com');
-      cy.get('#edit-champion-user-type-user-champion').check();
-      cy.get('input[name="supervisor_name"]').type('Dr. Supervisor');
-      cy.get('input[name="supervisor_email"]').type('supervisor@no-reply.com');
-
-      // Leave Carnegie code empty
-      cy.get('input[name="carnegie_classification"]').should('have.value', '');
-
-      // Submit form
-      cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
-        .contains('Submit').click();
-
-      // Should succeed (Carnegie code may not be required)
-      // Check for either success or specific validation message
-      cy.get('body').then($body => {
-        const text = $body.text();
-        const isSuccess = text.includes('Campus Champions Application Submitted');
-        const hasValidation = text.includes('required') || text.includes('Carnegie');
-        expect(isSuccess || hasValidation).to.be.true;
-      });
-    });
+  it('finds HBCU institutions in the type-ahead', () => {
+    cy.get('input[name="institution_name"]').type('Howard Univ');
+    cy.get('.ui-autocomplete', { timeout: 10000 }).should('be.visible');
+    cy.contains('.ui-autocomplete .ui-menu-item', 'Howard University').should('be.visible');
   });
 
-  describe('Carnegie Code with MSI Institutions', () => {
-    it('should find HBCU institutions via autocomplete', () => {
-      cy.get('input[name="carnegie_classification"]').type('Howard Univ');
-
-      cy.get('.ui-autocomplete', { timeout: 10000 }).should('be.visible');
-      cy.contains('Howard University').should('be.visible');
-    });
-
-    it('should find HSI institutions via autocomplete', () => {
-      cy.get('input[name="carnegie_classification"]').type('University of Texas at El Paso');
-
-      cy.get('.ui-autocomplete', { timeout: 10000 }).should('be.visible');
-      cy.contains('El Paso').should('be.visible');
-    });
+  it('finds HSI institutions in the type-ahead', () => {
+    cy.get('input[name="institution_name"]').type('University of Texas at El Paso');
+    cy.get('.ui-autocomplete', { timeout: 10000 }).should('be.visible');
+    cy.contains('.ui-autocomplete .ui-menu-item', 'El Paso').should('be.visible');
   });
 
-  // Note: Test users created with unique timestamps (carnegie-test-{timestamp})
-  // will not interfere with subsequent test runs. Manual cleanup may be needed
-  // periodically to remove old test submissions from the webform.
+  it('allows a free-text institution with no Carnegie match', () => {
+    // Institutions not in the Carnegie list (international, companies) are
+    // still accepted as free text; the Carnegie code simply stays blank.
+    cy.get('input[name="institution_name"]').type('Some Company LLC That Is Not Listed');
+    cy.get('input[name="carnegie_classification"]').should('have.value', '');
+  });
 });

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form-organization.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form-organization.cy.js
@@ -32,6 +32,17 @@ describe('Join Campus Champions Form - ACCESS Organization', () => {
     });
   });
 
+  describe('Prefill for a logged-in user with an organization', () => {
+    it('prefills the organization field from the account', () => {
+      // pecan@pie.org is a fixture account that has an organization set. Assert
+      // the field is prefilled with an entity-reference value (Label (nid))
+      // rather than a specific institution, since the fixture's org may change.
+      cy.loginUser('pecan@pie.org', 'Pecan');
+      cy.visit('/form/join-campus-champions');
+      cy.get(ORG_FIELD).invoke('val').should('match', /\(\d+\)\s*$/);
+    });
+  });
+
   describe('Selecting a real organization', () => {
     it('keeps institution and Carnegie hidden', () => {
       cy.get(ORG_FIELD).type('Arkansas for Medical');

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form-organization.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form-organization.cy.js
@@ -1,0 +1,76 @@
+/**
+ * Join Campus Champions Form - ACCESS Organization field (D8-2789)
+ *
+ * The applicant selects their ACCESS Organization directly. Institution and
+ * Carnegie fields are hidden until "Other" is chosen. In the Other flow the
+ * institution name is a type-ahead that fills the Carnegie code on selection
+ * and clears it on edit.
+ *
+ * Runs on the campus champions domain (CYPRESS_BASE_URL=campuschampions).
+ */
+describe('Join Campus Champions Form - ACCESS Organization', () => {
+
+  const ORG_FIELD = 'input[name="field_access_organization"]';
+  const CARNEGIE = 'input[name="carnegie_classification"]';
+  const INSTITUTION = 'input[name="institution_name"]';
+  // A real access_organization node used across the fixtures.
+  const REAL_ORG = 'University of Arkansas for Medical Sciences';
+
+  beforeEach(() => {
+    cy.visit('/form/join-campus-champions');
+  });
+
+  describe('Field display', () => {
+    it('shows the ACCESS Organization field and requires it', () => {
+      cy.get(ORG_FIELD).should('exist').and('be.visible');
+      cy.get(ORG_FIELD).should('have.attr', 'required');
+    });
+
+    it('hides institution and Carnegie fields by default', () => {
+      cy.get(INSTITUTION).should('not.be.visible');
+      cy.get(CARNEGIE).should('not.be.visible');
+    });
+  });
+
+  describe('Selecting a real organization', () => {
+    it('keeps institution and Carnegie hidden', () => {
+      cy.get(ORG_FIELD).type('Arkansas for Medical');
+      cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+        .contains(REAL_ORG).click();
+      cy.get(ORG_FIELD).should('contain.value', 'Arkansas');
+      cy.get(INSTITUTION).should('not.be.visible');
+      cy.get(CARNEGIE).should('not.be.visible');
+    });
+  });
+
+  describe('Selecting Other', () => {
+    beforeEach(() => {
+      cy.get(ORG_FIELD).type('Other');
+      cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+        .contains(/^Other/).click();
+    });
+
+    it('reveals institution and Carnegie fields', () => {
+      cy.get(INSTITUTION).should('be.visible');
+      cy.get(CARNEGIE).should('be.visible');
+    });
+
+    it('fills the Carnegie code from an institution type-ahead selection', () => {
+      cy.get(INSTITUTION).type('Stanford Univ');
+      cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+        .contains('Stanford University').click();
+      // Stanford's Carnegie unitid.
+      cy.get(CARNEGIE).should('have.value', '243744');
+    });
+
+    it('clears a stale Carnegie code when the institution is edited', () => {
+      cy.get(INSTITUTION).type('Stanford Univ');
+      cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+        .contains('Stanford University').click();
+      cy.get(CARNEGIE).should('have.value', '243744');
+      // Editing the institution invalidates the prior code.
+      cy.get(INSTITUTION).clear().type('Some Company LLC');
+      cy.get(CARNEGIE).should('have.value', '');
+    });
+  });
+});

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form-pending-redirect.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form-pending-redirect.cy.js
@@ -1,0 +1,72 @@
+/**
+ * Join Campus Champions Form - pending-submission redirect (D8-2789)
+ *
+ * A non-admin who already has a pending (status "new") Join Campus Champions
+ * submission is redirected from the blank form to edit that submission, so a
+ * second application cannot stack while one is under review. An approved
+ * champion (no pending submission) may open the blank form to start a fresh
+ * application, for example to change organizations.
+ *
+ * Enforced by JoinFormRedirectSubscriber on the entity.webform.canonical route.
+ *
+ * The test seeds a user and a submission via drush, then drives the browser as
+ * that user.
+ */
+describe('Join Campus Champions Form - pending redirect', () => {
+  const USERNAME = 'cypress-pending-redirect';
+  const PASSWORD = 'Test-Pending-123!';
+  const EMAIL = 'cypress-pending-redirect@no-reply.com';
+
+  // Seed the user and a pending submission owned by them; capture the sid.
+  before(() => {
+    cy.exec(`ddev drush user:cancel --delete-content -y ${USERNAME}`, { failOnNonZeroExit: false });
+    cy.exec(
+      `ddev drush user:create ${USERNAME} --mail="${EMAIL}" --password="${PASSWORD}"`,
+      { failOnNonZeroExit: false }
+    );
+    // Create a status=new submission owned by the new user. Print the sid on a
+    // line prefixed SID: so the test can read it back.
+    cy.exec(
+      `ddev drush php:eval "` +
+        `\\$uids = \\Drupal::entityQuery('user')->accessCheck(FALSE)->condition('name','${USERNAME}')->execute(); ` +
+        `\\$uid = \\$uids ? (int) reset(\\$uids) : 0; ` +
+        `\\$s = \\Drupal\\webform\\Entity\\WebformSubmission::create(['webform_id'=>'join_campus_champions','uid'=>\\$uid,'data'=>['status'=>'new','user_first_name'=>'Pending','user_last_name'=>'Redirect']]); ` +
+        `\\$s->save(); ` +
+        `print 'SID:' . \\$s->id();"`
+    ).then((res) => {
+      const match = res.stdout.match(/SID:(\d+)/);
+      expect(match, 'seeded submission sid').to.not.be.null;
+      Cypress.env('pendingSid', match[1]);
+    });
+  });
+
+  after(() => {
+    cy.exec(`ddev drush user:cancel --delete-content -y ${USERNAME}`, { failOnNonZeroExit: false });
+  });
+
+  it('redirects a user with a pending submission to edit it', () => {
+    cy.loginUser(USERNAME, PASSWORD);
+    cy.visit('/form/join-campus-champions');
+    // Landed on the submission edit page, not the blank add form.
+    cy.location('pathname').should((path) => {
+      expect(path).to.match(
+        new RegExp(`/webform/join_campus_champions/submissions/${Cypress.env('pendingSid')}/edit`)
+      );
+    });
+  });
+
+  it('does not redirect once the submission is no longer pending', () => {
+    // Flip the seeded submission to approved: no pending application remains, so
+    // the user may open the blank form to start a fresh one.
+    cy.exec(
+      `ddev drush php:eval "` +
+        `\\$s=\\Drupal\\webform\\Entity\\WebformSubmission::load(${'' + Cypress.env('pendingSid')}); ` +
+        `if(\\$s){\\$s->setElementData('status','approved'); \\$s->save();}"`
+    );
+    cy.loginUser(USERNAME, PASSWORD);
+    cy.visit('/form/join-campus-champions');
+    // Stayed on the blank add form (no redirect to the submission edit page).
+    cy.location('pathname').should('include', '/form/join-campus-champions');
+    cy.contains('Join Campus Champions');
+  });
+});

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form-validation.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form-validation.cy.js
@@ -1,0 +1,60 @@
+/**
+ * Join Campus Champions Form - duplicate account validation
+ *
+ * An anonymous applicant who enters the email or username of an existing
+ * account is told to log in first, instead of the form creating a second
+ * account. Enforced by the join form's validate handler (campuschampions
+ * form_alter attaches it to #validate).
+ *
+ * These assert the validation wiring stays intact — the handler is referenced
+ * by string name in #validate, so a rename that misses a reference silently
+ * disables this check.
+ *
+ * Uses existing fixture accounts to collide against:
+ * - walnut@pie.org / jerobert
+ *
+ * Runs anonymously (the check only fires for anonymous users).
+ */
+describe('Join Campus Champions Form - duplicate account validation', () => {
+  const EXISTING_EMAIL = 'walnut@pie.org';
+  const EXISTING_USERNAME = 'jerobert';
+
+  // Fill all required fields (including the Letter of Collaboration upload, which
+  // is #required) so submission reaches the server-side validate handler,
+  // overriding email/username per test.
+  const fillAndSubmit = ({ email, username }) => {
+    cy.visit('/form/join-campus-champions');
+    cy.get('#edit-letter-of-collaboration-upload')
+      .selectFile('cypress/files/northern-lights.pdf');
+    cy.contains('Remove', { timeout: 10000 });
+    cy.get('input[name="username"]').clear().type(username);
+    cy.get('input[name="user_first_name"]').type('Dup');
+    cy.get('input[name="user_last_name"]').type('Check');
+    cy.get('input[name="user_email"]').clear().type(email);
+    cy.get('#edit-champion-user-type-user-champion').check();
+    cy.get('input[name="supervisor_name"]').type('Sup Ervisor');
+    cy.get('input[name="supervisor_email"]').type('supervisor@no-reply.com');
+    // field_access_organization is #required; without it the browser blocks the
+    // submit before the server-side duplicate check runs.
+    cy.get('input[name="field_access_organization"]').type('Arkansas for Medical');
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+      .contains('University of Arkansas for Medical Sciences').click();
+    cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
+      .contains('Submit').click();
+  };
+
+  it('blocks an existing email and tells the applicant to log in', () => {
+    fillAndSubmit({ email: EXISTING_EMAIL, username: 'brand-new-username-xyz' });
+    cy.contains('There is an account associated with this email address', { timeout: 30000 })
+      .should('be.visible');
+    // The form did not proceed to the confirmation page.
+    cy.contains('Campus Champions Application Submitted').should('not.exist');
+  });
+
+  it('blocks an existing username and tells the applicant to log in', () => {
+    fillAndSubmit({ email: 'brand-new-email-xyz@no-reply.com', username: EXISTING_USERNAME });
+    cy.contains('There is an account associated with this username', { timeout: 30000 })
+      .should('be.visible');
+    cy.contains('Campus Champions Application Submitted').should('not.exist');
+  });
+});

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-join-form.cy.js
@@ -32,7 +32,9 @@ describe("Test registration page for becoming a campus champion", { retries: { r
     cy.get('#edit-champion-user-type-user-champion').check();
     cy.get('input[name="supervisor_name"]').type('Bob');
     cy.get('input[name="supervisor_email"]').type('bob@no-reply.com');
-    cy.get('input[name="carnegie_classification"]').type('167394');
+    cy.get('input[name="field_access_organization"]').type('Arkansas for Medical');
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+      .contains('University of Arkansas for Medical Sciences').click();
     cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit').contains('Submit').click();
     cy.contains('Campus Champions Application Submitted', { timeout: 30000 });
   });

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-status-transitions.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-status-transitions.cy.js
@@ -1,0 +1,133 @@
+/**
+ * Campus Champions submission status transitions (D8-2789)
+ *
+ * Two status transitions introduced for the change-institution flow:
+ *
+ * - Supersede on approval: approving a new application marks the applicant's
+ *   prior approved submissions "superseded", so only the current one is live.
+ * - Removed on removal: removing a champion marks their approved submissions
+ *   "removed".
+ *
+ * Both run through _campuschampions_set_champion_submission_status (from the
+ * ApproveCCAction and RemoveChampionForm respectively). Submissions are seeded
+ * via drush; the action under test is driven through the admin UI; the outcome
+ * is read back via drush.
+ */
+describe('Campus Champions status transitions', () => {
+  const USERNAME = 'cypress-status-xfer';
+  const EMAIL = 'cypress-status-xfer@no-reply.com';
+
+  // Read a submission's status element back via drush.
+  const statusOf = (sid) =>
+    cy.exec(
+      `ddev drush php:eval "\\$s=\\Drupal\\webform\\Entity\\WebformSubmission::load(${sid}); print \\$s ? (\\$s->getElementData('status') ?? '') : 'MISSING';"`
+    ).then((res) => res.stdout.trim());
+
+  // Poll the submission status until it matches, tolerating the approval batch's
+  // asynchronous commit (the VBO batch finishes a beat after the UI returns).
+  const expectStatus = (sid, expected, attempt = 0) => {
+    statusOf(sid).then((status) => {
+      if (status === expected || attempt >= 10) {
+        expect(status, `submission ${sid} status`).to.eq(expected);
+        return;
+      }
+      cy.wait(1000);
+      expectStatus(sid, expected, attempt + 1);
+    });
+  };
+
+  // Create the test user (idempotent).
+  const seedUser = () => {
+    cy.exec(`ddev drush user:cancel --delete-content -y ${USERNAME}`, { failOnNonZeroExit: false });
+    cy.exec(`ddev drush user:create ${USERNAME} --mail="${EMAIL}" --password="Test-Status-123!"`);
+    // Mark them a champion so RemoveChampionForm accepts them.
+    cy.exec(
+      `ddev drush php:eval "` +
+        `\\$uids=\\Drupal::entityQuery('user')->accessCheck(FALSE)->condition('name','${USERNAME}')->execute(); ` +
+        `\\$u=\\Drupal\\user\\Entity\\User::load(reset(\\$uids)); ` +
+        `\\$u->set('field_is_cc',1); \\$u->addRole('research_computing_facilitator'); \\$u->save(); ` +
+        `print 'UID:'.\\$u->id();"`
+    );
+  };
+
+  // Create a submission owned by the test user with the given status and name;
+  // return its sid.
+  const seedSubmission = (status, firstName, lastName) =>
+    cy.exec(
+      `ddev drush php:eval "` +
+        `\\$uids=\\Drupal::entityQuery('user')->accessCheck(FALSE)->condition('name','${USERNAME}')->execute(); ` +
+        `\\$uid=(int) reset(\\$uids); ` +
+        // Include user_email + username so ApproveCCAction resolves the
+        // submission back to this same account (it looks the account up by
+        // email, then username), and the supersede runs against this user.
+        `\\$s=\\Drupal\\webform\\Entity\\WebformSubmission::create(['webform_id'=>'join_campus_champions','uid'=>\\$uid,'data'=>['status'=>'${status}','username'=>'${USERNAME}','user_email'=>'${EMAIL}','user_first_name'=>'${firstName}','user_last_name'=>'${lastName}','carnegie_classification'=>'166683','champion_user_type'=>'user_champion','supervisor_name'=>'Sup','supervisor_email'=>'sup@no-reply.com']]); ` +
+        `\\$s->save(); print 'SID:'.\\$s->id();"`
+    ).then((res) => res.stdout.match(/SID:(\d+)/)[1]);
+
+  afterEach(() => {
+    cy.exec(`ddev drush user:cancel --delete-content -y ${USERNAME}`, { failOnNonZeroExit: false });
+  });
+
+  // Invoke the shared status-transition helper for a user via drush. This is
+  // the exact function ApproveCCAction and RemoveChampionForm call.
+  const setChampionStatus = (uid, newStatus, excludeSid) =>
+    cy.exec(
+      `ddev drush php:eval "` +
+        `print _campuschampions_set_champion_submission_status(${uid}, '${newStatus}'` +
+        (excludeSid ? `, ${excludeSid}` : '') +
+        `);"`
+    );
+
+  // Resolve the seeded user's uid.
+  const uidOf = () =>
+    cy.exec(
+      `ddev drush php:eval "\\$ids=\\Drupal::entityQuery('user')->accessCheck(FALSE)->condition('name','${USERNAME}')->execute(); print \\$ids ? (int) reset(\\$ids) : 0;"`
+    ).then((res) => parseInt(res.stdout.trim(), 10));
+
+  it('supersedes prior approved submissions, keeping the excluded one', () => {
+    // The supersede transition (invoked by ApproveCCAction on approval) marks a
+    // user's other approved submissions superseded while leaving the just-
+    // approved one untouched. Drive the helper directly: the webform validation
+    // and account-resolution that ApproveCCAction layers on top are exercised by
+    // the approve-action spec; here we isolate the transition itself.
+    seedUser();
+    let keepSid;
+    let priorSid;
+    // Two approved submissions for the same user: one is the "current" approval
+    // to keep, the other a prior approval that should be superseded.
+    seedSubmission('approved', 'KeepOrg', 'Xfer').then((sid) => { keepSid = sid; });
+    seedSubmission('approved', 'PriorOrg', 'Xfer').then((sid) => { priorSid = sid; });
+
+    // Supersede the user's approved submissions except the one being kept.
+    cy.then(() => {
+      uidOf().then((uid) => {
+        setChampionStatus(uid, 'superseded', keepSid);
+      });
+    });
+
+    // The prior approval is superseded; the kept one stays approved.
+    cy.then(() => {
+      expectStatus(priorSid, 'superseded');
+      expectStatus(keepSid, 'approved');
+    });
+  });
+
+  it('marks a champion submission removed when the champion is removed', () => {
+    seedUser();
+    let approvedSid;
+    seedSubmission('approved', 'ToRemove', 'Xfer').then((sid) => { approvedSid = sid; });
+
+    // Remove the champion through the remove-champion admin form.
+    cy.loginUser('pecan@pie.org', 'Pecan');
+    cy.visit('/remove-champion');
+    cy.get('input[data-drupal-selector="edit-champion"]').type(USERNAME);
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 }).first().click();
+    cy.get('input[type="submit"][value="Remove"]').click();
+    // Form completes (redirect / confirmation).
+    cy.get('body', { timeout: 10000 }).should('exist');
+
+    cy.then(() => {
+      expectStatus(approvedSid, 'removed');
+    });
+  });
+});

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-user-creation.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-user-creation.cy.js
@@ -1,132 +1,95 @@
 /**
  * Campus Champions User Creation Tests
  *
- * Tests the user creation process via the Join Campus Champions webform.
- * Verifies that:
- * - User is created when form is submitted
- * - User appears in the CC applications admin view
- * - Carnegie code is captured in the submission
+ * The join form creates a user from the submission. The applicant selects
+ * their ACCESS Organization directly; the Carnegie code is derived from the
+ * selected organization. Tests cover:
+ * - A user is created and appears in the applications admin view.
+ * - Selecting an HBCU organization derives its Carnegie code.
+ * - The "Other" path reveals institution + Carnegie fields for manual entry.
  *
- * Uses the CreateUserHandler webform handler in the campuschampions module.
- *
- * Note: The CreateUserHandler populates:
- * - field_institution from Carnegie code lookup
- * - field_carnegie_code from the submitted code
- * - Assigns research_computing_facilitator role
+ * Note: CreateUserHandler populates field_access_organization from the
+ * selection and field_carnegie_code from that organization (or the manual
+ * entry in the Other flow).
  */
 describe('Campus Champions User Creation', () => {
 
-  // Generate unique identifier for test users
   const timestamp = Date.now();
   const testUsername = `cctest-${timestamp}`;
   const testEmail = `cctest-${timestamp}@no-reply.com`;
 
-  // Known valid Carnegie codes
-  const testInstitution = {
-    code: '166683',
-    name: 'Massachusetts Institute of Technology'
+  // Real access_organization nodes and the Carnegie code each one carries.
+  const MIT = { name: 'Massachusetts Institute of Technology', type: 'Massachusetts Inst' };
+  const HBCU = { name: 'Alabama A&M University', type: 'Alabama A' };
+
+  const selectOrg = (typed, label) => {
+    cy.get('input[name="field_access_organization"]').type(typed);
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 }).contains(label).click();
+  };
+
+  const fillCommon = (username, email, firstName) => {
+    cy.get('#edit-letter-of-collaboration-upload').selectFile('cypress/files/northern-lights.pdf');
+    cy.contains(/northern-lights.*\.pdf/, { timeout: 10000 }).should('be.visible');
+    cy.get('input[name="username"]').type(username);
+    cy.get('input[name="user_first_name"]').type(firstName);
+    cy.get('input[name="user_last_name"]').type('Test');
+    cy.get('input[name="user_email"]').type(email);
+    cy.get('#edit-champion-user-type-user-champion').check();
+    cy.get('input[name="supervisor_name"]').type('Dr. Test Supervisor');
+    cy.get('input[name="supervisor_email"]').type('supervisor-test@no-reply.com');
   };
 
   describe('User Creation via Join Form', () => {
-    it('should create a new user when form is submitted with Carnegie code', () => {
+    it('should create a new user when the form is submitted with an organization', () => {
       cy.visit('/form/join-campus-champions');
+      fillCommon(testUsername, testEmail, 'Integration');
+      selectOrg(MIT.type, MIT.name);
 
-      // Fill out the form
-      cy.get('#edit-letter-of-collaboration-upload')
-        .selectFile('cypress/files/northern-lights.pdf');
-
-      // Wait for file upload
-      cy.contains(/northern-lights.*\.pdf/, { timeout: 10000 }).should('be.visible');
-
-      cy.get('input[name="username"]').type(testUsername);
-      cy.get('input[name="user_first_name"]').type('Integration');
-      cy.get('input[name="user_last_name"]').type('Test');
-      cy.get('input[name="user_email"]').type(testEmail);
-      cy.get('#edit-champion-user-type-user-champion').check();
-      cy.get('input[name="supervisor_name"]').type('Dr. Test Supervisor');
-      cy.get('input[name="supervisor_email"]').type('supervisor-test@no-reply.com');
-      cy.get('input[name="carnegie_classification"]').type(testInstitution.code);
-
-      // Submit the form
       cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
         .contains('Submit').click();
-
-      // Verify submission success
       cy.contains('Campus Champions Application Submitted');
     });
 
-    it('should show the submission in CC applications admin view', () => {
-      // Login as CC admin
+    it('should show the submission in the CC applications admin view', () => {
       cy.loginUser('pecan@pie.org', 'Pecan');
       cy.visit('/cc-applications');
-
-      // The new submission should appear (search by first name)
-      cy.get('body').then($body => {
+      cy.get('body').then(($body) => {
         const text = $body.text();
-        // Look for the test user's first name in the applications
-        const hasSubmission = text.includes('Integration') || text.includes(testUsername);
-        expect(hasSubmission).to.be.true;
+        expect(text.includes('Integration') || text.includes(testUsername)).to.be.true;
       });
     });
   });
 
   describe('User Creation with HBCU Institution', () => {
-    const hbcuCode = '100654'; // Alabama A & M University (HBCU)
     const hbcuUsername = `cctest-hbcu-${timestamp}`;
     const hbcuEmail = `cctest-hbcu-${timestamp}@no-reply.com`;
 
-    it('should accept HBCU Carnegie code in form submission', () => {
+    it('accepts an HBCU organization selection', () => {
       cy.visit('/form/join-campus-champions');
-
-      cy.get('#edit-letter-of-collaboration-upload')
-        .selectFile('cypress/files/northern-lights.pdf');
-
-      cy.contains(/northern-lights.*\.pdf/, { timeout: 10000 }).should('be.visible');
-
-      cy.get('input[name="username"]').type(hbcuUsername);
-      cy.get('input[name="user_first_name"]').type('HBCU');
-      cy.get('input[name="user_last_name"]').type('Test');
-      cy.get('input[name="user_email"]').type(hbcuEmail);
-      cy.get('#edit-champion-user-type-user-champion').check();
-      cy.get('input[name="supervisor_name"]').type('Dr. HBCU Supervisor');
-      cy.get('input[name="supervisor_email"]').type('hbcu-supervisor@no-reply.com');
-      cy.get('input[name="carnegie_classification"]').type(hbcuCode);
+      fillCommon(hbcuUsername, hbcuEmail, 'HBCU');
+      selectOrg(HBCU.type, HBCU.name);
 
       cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
         .contains('Submit').click();
-
       cy.contains('Campus Champions Application Submitted');
     });
   });
 
-  describe('User Creation Without Carnegie Code', () => {
-    it('should handle form when Carnegie code checkbox is checked', () => {
-      const noCarnegieUsername = `cctest-nocarnegie-${timestamp}`;
-      const noCarnegieEmail = `cctest-nocarnegie-${timestamp}@no-reply.com`;
+  describe('User Creation via the Other path', () => {
+    it('reveals institution and Carnegie fields when Other is chosen', () => {
+      const otherUsername = `cctest-other-${timestamp}`;
+      const otherEmail = `cctest-other-${timestamp}@no-reply.com`;
 
       cy.visit('/form/join-campus-champions');
+      fillCommon(otherUsername, otherEmail, 'OtherPath');
+      selectOrg('Other', /^Other/);
 
-      cy.get('#edit-letter-of-collaboration-upload')
-        .selectFile('cypress/files/northern-lights.pdf');
+      // Institution + Carnegie fields are now visible for manual entry.
+      cy.get('input[name="institution_name"]').should('be.visible')
+        .type('Test Non-Carnegie Institution');
+      // Carnegie is required in the Other flow; enter it manually.
+      cy.get('input[name="carnegie_classification"]').should('be.visible').type('000000');
 
-      cy.contains(/northern-lights.*\.pdf/, { timeout: 10000 }).should('be.visible');
-
-      cy.get('input[name="username"]').type(noCarnegieUsername);
-      cy.get('input[name="user_first_name"]').type('NoCarnegie');
-      cy.get('input[name="user_last_name"]').type('Test');
-      cy.get('input[name="user_email"]').type(noCarnegieEmail);
-      cy.get('#edit-champion-user-type-user-champion').check();
-      cy.get('input[name="supervisor_name"]').type('Dr. NoCarnegie Supervisor');
-      cy.get('input[name="supervisor_email"]').type('nocarnegie-supervisor@no-reply.com');
-
-      // Check the "I can't find my Carnegie Code" checkbox
-      cy.get('input[name="i_can_t_find_my_carnegie_code"]').check();
-
-      // Now the institution fields should be visible
-      cy.get('input[name="institution_name"]').should('be.visible');
-      cy.get('input[name="institution_name"]').type('Test Non-Carnegie Institution');
-
-      // Fill address fields
       cy.get('input[name="institution_street_address[address]"]').type('123 Test Street');
       cy.get('input[name="institution_street_address[city]"]').type('Test City');
       cy.get('select[name="institution_street_address[state_province]"]').select('Massachusetts');
@@ -135,8 +98,6 @@ describe('Campus Champions User Creation', () => {
 
       cy.get('#webform-submission-join-campus-champions-add-form > #edit-actions > #edit-submit')
         .contains('Submit').click();
-
-      // Should succeed
       cy.contains('Campus Champions Application Submitted');
     });
   });

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-user-form-region-validation.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-user-form-region-validation.cy.js
@@ -11,26 +11,29 @@
  * disables this check.
  *
  * Edits an existing regular user as an administrator:
- * - administrator@amptesting.com edits authenticated_test_user (uid 68170)
+ * - administrator@amptesting.com edits authenticated_test_user
  */
 describe('User form - Campus Champions program membership guard', () => {
-  const TEST_UID = 68170;
   const CC_OPTION = '572';
 
-  // Seed the identity fields this user is missing so the form can POST and
-  // reach the server-side validate handler (an empty required First/Last name
-  // otherwise blocks submission client-side, never running our validation).
+  // Resolve the fixture user's uid by name — it is assigned at fixture-build
+  // time and is not stable across DB builds, so it must not be hardcoded.
   before(() => {
     cy.exec(
-      `ddev drush php:eval "\\$u=\\Drupal\\user\\Entity\\User::load(${TEST_UID}); if(\\$u){\\$u->set('field_user_first_name','Region'); \\$u->set('field_user_last_name','Tester'); \\$u->save();}"`,
-      { failOnNonZeroExit: false }
-    );
+      `ddev drush php:eval "\\$u = user_load_by_name('authenticated_test_user'); print \\$u ? \\$u->id() : 0;"`
+    ).then((res) => {
+      const uid = parseInt(res.stdout.trim(), 10);
+      expect(uid, 'authenticated_test_user uid').to.be.greaterThan(0);
+      Cypress.env('testUid', uid);
+    });
   });
 
-  // Fill the remaining required fields on the user form, overriding is_cc per
-  // test. Assumes First/Last name are already seeded (see before()).
+  // Toggle is_cc and select the Campus Champions program, then submit. The
+  // authenticated_test_user fixture already has a name and organization (set in
+  // amp_dev), so the form's required identity/org fields are satisfied without
+  // this spec mutating the shared user.
   const prepareForm = ({ isCc }) => {
-    cy.visit(`/user/${TEST_UID}/edit`);
+    cy.visit(`/user/${Cypress.env('testUid')}/edit`);
     if (isCc) {
       cy.get('#edit-field-is-cc-value').check({ force: true });
     }
@@ -39,12 +42,6 @@ describe('User form - Campus Champions program membership guard', () => {
     }
     // Select Campus Champions in the multi-select Programs list.
     cy.get('select[name="field_region[]"]').select(CC_OPTION);
-    // field_access_organization is a required entity autocomplete on this domain.
-    cy.get('input[name="field_access_organization[0][target_id]"]')
-      .clear()
-      .type('Arkansas for Medical');
-    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
-      .contains('University of Arkansas for Medical Sciences').click();
   };
 
   beforeEach(() => {
@@ -55,7 +52,7 @@ describe('User form - Campus Champions program membership guard', () => {
   // fixture stays clean regardless of which assertions ran.
   afterEach(() => {
     cy.exec(
-      `ddev drush php:eval "\\$u=\\Drupal\\user\\Entity\\User::load(${TEST_UID}); if(\\$u){\\$u->set('field_is_cc',0); \\$u->set('field_region',[]); \\$u->save();}"`,
+      `ddev drush php:eval "\\$u=user_load_by_name('authenticated_test_user'); if(\\$u){\\$u->set('field_is_cc',0); \\$u->set('field_region',[]); \\$u->save();}"`,
       { failOnNonZeroExit: false }
     );
   });

--- a/tests/cypress/cypress/e2e/campuschampions/campuschampions-user-form-region-validation.cy.js
+++ b/tests/cypress/cypress/e2e/campuschampions/campuschampions-user-form-region-validation.cy.js
@@ -1,0 +1,79 @@
+/**
+ * User form - Campus Champions program requires membership
+ *
+ * Selecting "Campus Champions" in a user's Programs (field_region) without the
+ * is_cc flag set is blocked with a message pointing at the join form. Enforced
+ * by the user form's validate handler (campuschampions form_alter attaches it
+ * to #validate).
+ *
+ * Asserts the validation wiring stays intact — the handler is referenced by
+ * string name in #validate, so a rename that misses a reference silently
+ * disables this check.
+ *
+ * Edits an existing regular user as an administrator:
+ * - administrator@amptesting.com edits authenticated_test_user (uid 68170)
+ */
+describe('User form - Campus Champions program membership guard', () => {
+  const TEST_UID = 68170;
+  const CC_OPTION = '572';
+
+  // Seed the identity fields this user is missing so the form can POST and
+  // reach the server-side validate handler (an empty required First/Last name
+  // otherwise blocks submission client-side, never running our validation).
+  before(() => {
+    cy.exec(
+      `ddev drush php:eval "\\$u=\\Drupal\\user\\Entity\\User::load(${TEST_UID}); if(\\$u){\\$u->set('field_user_first_name','Region'); \\$u->set('field_user_last_name','Tester'); \\$u->save();}"`,
+      { failOnNonZeroExit: false }
+    );
+  });
+
+  // Fill the remaining required fields on the user form, overriding is_cc per
+  // test. Assumes First/Last name are already seeded (see before()).
+  const prepareForm = ({ isCc }) => {
+    cy.visit(`/user/${TEST_UID}/edit`);
+    if (isCc) {
+      cy.get('#edit-field-is-cc-value').check({ force: true });
+    }
+    else {
+      cy.get('#edit-field-is-cc-value').uncheck({ force: true });
+    }
+    // Select Campus Champions in the multi-select Programs list.
+    cy.get('select[name="field_region[]"]').select(CC_OPTION);
+    // field_access_organization is a required entity autocomplete on this domain.
+    cy.get('input[name="field_access_organization[0][target_id]"]')
+      .clear()
+      .type('Arkansas for Medical');
+    cy.get('.ui-autocomplete .ui-menu-item', { timeout: 10000 })
+      .contains('University of Arkansas for Medical Sciences').click();
+  };
+
+  beforeEach(() => {
+    cy.loginUser('administrator@amptesting.com', 'b8QW]X9h7#5n');
+  });
+
+  // Leave the user without the Campus Champions program after each test so the
+  // fixture stays clean regardless of which assertions ran.
+  afterEach(() => {
+    cy.exec(
+      `ddev drush php:eval "\\$u=\\Drupal\\user\\Entity\\User::load(${TEST_UID}); if(\\$u){\\$u->set('field_is_cc',0); \\$u->set('field_region',[]); \\$u->save();}"`,
+      { failOnNonZeroExit: false }
+    );
+  });
+
+  it('blocks selecting the Campus Champions program when is_cc is not set', () => {
+    prepareForm({ isCc: false });
+    cy.get('#edit-submit').click();
+
+    cy.contains('Please join the Campus Champions by submitting', { timeout: 30000 })
+      .should('be.visible');
+  });
+
+  it('allows the Campus Champions program when is_cc is set', () => {
+    prepareForm({ isCc: true });
+    cy.get('#edit-submit').click();
+
+    // Saved: the guard message is absent and Drupal shows the saved notice.
+    cy.contains('Please join the Campus Champions by submitting').should('not.exist');
+    cy.contains('The changes have been saved', { timeout: 30000 }).should('exist');
+  });
+});

--- a/tests/cypress/cypress/e2e/ccmnet/access-organization-field.cy.js
+++ b/tests/cypress/cypress/e2e/ccmnet/access-organization-field.cy.js
@@ -90,10 +90,10 @@ describe("ACCESS Organization field - CCMNet", () => {
     });
 
     it("Should handle Other option on CCMNet user edit form", () => {
-      // Log in as an administrator: the org field is read-only for a non-admin
-      // who already has an organization (the D8-2789 change-institution guard),
-      // so editing it to 'Other' to test the Institution reveal requires admin.
-      cy.loginUser('administrator@amptesting.com', 'b8QW]X9h7#5n');
+      // Login as authenticated user. The read-only-org guard is scoped to the
+      // campuschampions domain only, so on CCMNet the org field stays editable
+      // for a non-admin even when they have an organization.
+      cy.loginUser('authenticated@amptesting.com', '6%l7iF}6(4tI');
 
       // Visit user edit page
       cy.visit('/user/edit');

--- a/tests/cypress/cypress/e2e/ccmnet/access-organization-field.cy.js
+++ b/tests/cypress/cypress/e2e/ccmnet/access-organization-field.cy.js
@@ -90,9 +90,11 @@ describe("ACCESS Organization field - CCMNet", () => {
     });
 
     it("Should handle Other option on CCMNet user edit form", () => {
-      // Login as authenticated user
-      cy.loginUser('authenticated@amptesting.com', '6%l7iF}6(4tI');
-      
+      // Log in as an administrator: the org field is read-only for a non-admin
+      // who already has an organization (the D8-2789 change-institution guard),
+      // so editing it to 'Other' to test the Institution reveal requires admin.
+      cy.loginUser('administrator@amptesting.com', 'b8QW]X9h7#5n');
+
       // Visit user edit page
       cy.visit('/user/edit');
       

--- a/tests/cypress/package-lock.json
+++ b/tests/cypress/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "cypress",
       "dependencies": {
         "axe-core": "^4.10.3",
         "cypress-axe": "^1.7.0"

--- a/tests/cypress/package-lock.json
+++ b/tests/cypress/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "cypress",
       "dependencies": {
         "axe-core": "^4.10.3",
         "cypress-axe": "^1.7.0"

--- a/web/modules/custom/campuschampions/campuschampions.install
+++ b/web/modules/custom/campuschampions/campuschampions.install
@@ -1382,3 +1382,81 @@ function campuschampions_update_10008(&$sandbox) {
     '@rem' => $removed,
   ]);
 }
+
+/**
+ * Clean up non-numeric Carnegie codes on legacy Join Campus Champions rows.
+ *
+ * Some older submissions stored a Carnegie *classification* string (e.g. "R1",
+ * "R2:Doctoral Universities…", or free text like "UCLA") in the numeric
+ * carnegie_classification field, from before the field became org-derived.
+ * Re-derive the real code from the submitter account's ACCESS Organization
+ * where possible; blank it when the account has no organization. Also delete a
+ * known test submission from a sweetandfizzy tester.
+ */
+function campuschampions_update_10009() {
+  $db = \Drupal::database();
+  $storage = \Drupal::entityTypeManager()->getStorage('webform_submission');
+
+  // Delete the known test submission (guarded by both sid and email so it can
+  // never match anything else).
+  $test_sid = 5980;
+  $test = $storage->load($test_sid);
+  $deleted = 0;
+  if ($test && $test->getWebform()->id() === 'join_campus_champions') {
+    $email = $test->getElementData('user_email');
+    if (is_string($email) && strtolower($email) === 'sdepaula@sweetandfizzy.com') {
+      $test->delete();
+      $deleted = 1;
+    }
+  }
+
+  // Find join submissions whose carnegie value is non-empty and non-numeric.
+  $sids = $db->select('webform_submission_data', 'd')
+    ->fields('d', ['sid'])
+    ->condition('d.name', 'carnegie_classification')
+    ->condition('d.value', '', '<>')
+    ->where("d.value NOT REGEXP '^[0-9]+$'")
+    ->execute()->fetchCol();
+
+  $fixed = 0;
+  $blanked = 0;
+  foreach ($storage->loadMultiple($sids) as $submission) {
+    if ($submission->getWebform()->id() !== 'join_campus_champions') {
+      continue;
+    }
+    // Resolve the submitter account: email first, then username (matches how
+    // the approval action reconciles identity elsewhere).
+    $data = $submission->getData();
+    $account = FALSE;
+    if (!empty($data['user_email'])) {
+      $account = user_load_by_mail($data['user_email']);
+    }
+    if (!$account && !empty($data['username'])) {
+      $account = user_load_by_name($data['username']);
+    }
+
+    $code = '';
+    if ($account && $account->hasField('field_access_organization')
+      && !$account->get('field_access_organization')->isEmpty()) {
+      $org = $account->get('field_access_organization')->entity;
+      if ($org && $org->hasField('field_carnegie_code')) {
+        $code = (string) $org->get('field_carnegie_code')->value;
+      }
+    }
+
+    $submission->setElementData('carnegie_classification', $code);
+    $submission->resave();
+    if ($code === '') {
+      $blanked++;
+    }
+    else {
+      $fixed++;
+    }
+  }
+
+  return t('Deleted @del test submission; re-derived Carnegie code on @fixed rows; blanked @blank with no resolvable organization.', [
+    '@del' => $deleted,
+    '@fixed' => $fixed,
+    '@blank' => $blanked,
+  ]);
+}

--- a/web/modules/custom/campuschampions/campuschampions.install
+++ b/web/modules/custom/campuschampions/campuschampions.install
@@ -1297,8 +1297,13 @@ function campuschampions_update_10007() {
  *    'superseded' (prior organizations).
  * 3. Mark approved submissions whose account is no longer a champion
  *    (field_is_cc = 0) as 'removed'.
+ *
+ * Runs in a single pass — the join submission set is small (a few hundred rows),
+ * so no batching is needed. Ownership is resolved against the current account
+ * matching each submission's email/username, which is the intended behaviour for
+ * this one-time historical backfill.
  */
-function campuschampions_update_10008(&$sandbox) {
+function campuschampions_update_10008() {
   $storage = \Drupal::entityTypeManager()->getStorage('webform_submission');
 
   // Group all join submissions by resolved champion account.

--- a/web/modules/custom/campuschampions/campuschampions.install
+++ b/web/modules/custom/campuschampions/campuschampions.install
@@ -1285,3 +1285,100 @@ function campuschampions_update_10007() {
 
   return t('Converted @count state names to abbreviations and refreshed stats.', ['@count' => $updated]);
 }
+
+/**
+ * Reconcile Join Campus Champions submission ownership and backfill statuses.
+ *
+ * Sturdy backfill for the change-institution work:
+ * 1. Point each submission's owner (uid) at the real champion account,
+ *    resolved by the same email-then-username logic the approval action uses,
+ *    so uid becomes the authoritative account link for all historical rows.
+ * 2. Per champion, mark every approved submission except their newest as
+ *    'superseded' (prior organizations).
+ * 3. Mark approved submissions whose account is no longer a champion
+ *    (field_is_cc = 0) as 'removed'.
+ */
+function campuschampions_update_10008(&$sandbox) {
+  $storage = \Drupal::entityTypeManager()->getStorage('webform_submission');
+
+  // Group all join submissions by resolved champion account.
+  $sids = $storage->getQuery()
+    ->condition('webform_id', 'join_campus_champions')
+    ->accessCheck(FALSE)
+    ->execute();
+
+  // uid => [['sid' => int, 'created' => int, 'status' => string], ...].
+  $by_user = [];
+  $reowned = 0;
+  foreach ($storage->loadMultiple($sids) as $submission) {
+    $data = $submission->getData();
+    // Resolve the real account: email first, then username (mirrors
+    // ApproveCCAction so ownership matches how identity is reconciled there).
+    $account = FALSE;
+    if (!empty($data['user_email'])) {
+      $account = user_load_by_mail($data['user_email']);
+    }
+    if (!$account && !empty($data['username'])) {
+      $account = user_load_by_name($data['username']);
+    }
+    if (!$account) {
+      // Fall back to the current owner if it is a real, non-anonymous account.
+      $owner = $submission->getOwner();
+      if ($owner && !$owner->isAnonymous()) {
+        $account = $owner;
+      }
+    }
+    if (!$account) {
+      continue;
+    }
+
+    $uid = (int) $account->id();
+    if ((int) $submission->getOwnerId() !== $uid) {
+      $submission->setOwnerId($uid);
+      $submission->resave();
+      $reowned++;
+    }
+
+    $by_user[$uid][] = [
+      'sid' => (int) $submission->id(),
+      'created' => (int) $submission->getCreatedTime(),
+      'status' => $data['status'] ?? '',
+    ];
+  }
+
+  $superseded = 0;
+  $removed = 0;
+  foreach ($by_user as $uid => $rows) {
+    $account = \Drupal\user\Entity\User::load($uid);
+    $is_champion = $account && $account->hasField('field_is_cc') && (bool) $account->get('field_is_cc')->value;
+
+    // Approved rows only, newest first.
+    $approved = array_filter($rows, fn($r) => $r['status'] === 'approved');
+    usort($approved, fn($a, $b) => $b['created'] <=> $a['created']);
+
+    foreach ($approved as $index => $row) {
+      $submission = $storage->load($row['sid']);
+      if (!$submission) {
+        continue;
+      }
+      if (!$is_champion) {
+        // Account is no longer in the program: every approved row is removed.
+        $submission->setElementData('status', 'removed');
+        $submission->resave();
+        $removed++;
+      }
+      elseif ($index > 0) {
+        // Still a champion: keep the newest approved, supersede the rest.
+        $submission->setElementData('status', 'superseded');
+        $submission->resave();
+        $superseded++;
+      }
+    }
+  }
+
+  return t('Reconciled @reowned submission owners; superseded @sup prior organizations; marked @rem as removed.', [
+    '@reowned' => $reowned,
+    '@sup' => $superseded,
+    '@rem' => $removed,
+  ]);
+}

--- a/web/modules/custom/campuschampions/campuschampions.libraries.yml
+++ b/web/modules/custom/campuschampions/campuschampions.libraries.yml
@@ -7,3 +7,13 @@ assets:
   js:
     js/odometer.min.js: {}
     js/campuschampions.js: {}
+
+join-org-toggle:
+  version: 1.x
+  js:
+    js/join-org-toggle.js: {}
+  dependencies:
+    - core/jquery
+    - core/once
+    - core/drupal
+    - core/jquery.ui.autocomplete

--- a/web/modules/custom/campuschampions/campuschampions.module
+++ b/web/modules/custom/campuschampions/campuschampions.module
@@ -7,10 +7,14 @@
 use Drupal\campuschampions\Plugin\CarnegieCodesLookup;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 use Drupal\views\ResultRow;
 use Drupal\views\ViewExecutable;
 
@@ -98,6 +102,39 @@ function campuschampions_form_alter(&$form, &$form_state, $form_id) {
   $start = 'contact_message';
   if (@substr_compare($form_id, $start, 0, strlen($start)) == 0) {
     $form['actions']['preview']['#access'] = FALSE;
+  }
+
+  // Once the organization has been set, only administrators may change it.
+  // Everyone else gets a read-only widget with a link to request a change.
+  // Campus Champions domain only -- the Letter of Collaboration is what ties
+  // the organization to the account here.
+  $is_cc_domain = \Drupal::service('access_misc.sitetools')->getDomainId() == 'campuschampions_cyberinfrastructure_org';
+  if ($is_cc_domain
+    && in_array($form_id, ['user_form', 'user_register_form'], TRUE)
+    && isset($form['field_access_organization']['widget'][0]['target_id'])) {
+    $element = &$form['field_access_organization']['widget'][0]['target_id'];
+    $is_admin = in_array('administrator', \Drupal::currentUser()->getRoles());
+    $has_value = FALSE;
+    $form_object = $form_state->getFormObject();
+    if ($form_object instanceof EntityFormInterface) {
+      $account = $form_object->getEntity();
+      $has_value = $account instanceof UserInterface
+        && !$account->get('field_access_organization')->isEmpty();
+    }
+
+    if ($has_value && !$is_admin) {
+      $element['#attributes']['readonly'] = 'readonly';
+      // #disabled makes the form API ignore any submitted value and keep
+      // the stored one, so the readonly attribute cannot be bypassed.
+      $element['#disabled'] = TRUE;
+      // Prevent the autocomplete from offering replacement values.
+      $element['#autocomplete_route_name'] = NULL;
+    }
+
+    $element['#suffix'] = ($element['#suffix'] ?? '') . '<div class="description mb-3">'
+      . Link::fromTextAndUrl(t('Update Letter of Collaboration'), Url::fromUri('internal:/form/join-campus-champions'))->toString()
+      . '</div>';
+    unset($element);
   }
 }
 

--- a/web/modules/custom/campuschampions/campuschampions.module
+++ b/web/modules/custom/campuschampions/campuschampions.module
@@ -2,6 +2,7 @@
 
 /**
  * @file
+ * Hooks and helpers for the Campus Champions module.
  */
 
 use Drupal\campuschampions\Plugin\CarnegieCodesLookup;
@@ -21,13 +22,13 @@ use Drupal\webform\WebformSubmissionInterface;
 use Drupal\views\ViewExecutable;
 
 /**
- *
+ * Implements hook_form_alter().
  */
 function campuschampions_form_alter(&$form, &$form_state, $form_id) {
   if ($form_id == 'user_form') {
     $form['field_carnegie_code']['widget'][0]['value']['#autocomplete_route_name'] = 'campuschampions.autocomplete';
 
-    // Add validation for Carnegie code field
+    // Add validation for Carnegie code field.
     $form['#validate'][] = 'campuschampions_user_form_validate';
   }
   global $user;
@@ -101,7 +102,8 @@ function campuschampions_form_alter(&$form, &$form_state, $form_id) {
       $form['field_is_cc']['widget']['#access'] = FALSE;
     }
 
-    // Don't allow people to join Campus Champions field unless the is_cc field is checked.
+    // Don't allow people to join the Campus Champions field unless the is_cc
+    // field is checked.
     if ($form['#validate'] != 'validate_user_form') {
       $form['#validate'][] = 'validate_user_form';
     }
@@ -233,7 +235,7 @@ function _campuschampions_set_champion_submission_status(int $uid, string $new_s
 if (!function_exists('validate_form')) {
 
   /**
-   *
+   * Validates the Campus Champions join form for duplicate email/username.
    */
   function validate_form(array &$form, FormStateInterface $form_state) {
     $user_email = $form_state->getValue('user_email');
@@ -270,7 +272,7 @@ if (!function_exists('validate_form')) {
 if (!function_exists('validate_user_form')) {
 
   /**
-   *
+   * Requires the is_cc field before assigning the Campus Champions program.
    */
   function validate_user_form(array &$form, FormStateInterface $form_state) {
     $programs = $form_state->getValue('field_region');
@@ -310,9 +312,6 @@ function campuschampions_theme() {
  * Send mail to approved campus champions.
  */
 function campuschampions_mail($key, &$message, $params) {
-  $options = [
-    'langcode' => $message['langcode'],
-  ];
   switch ($key) {
     case 'approve_campuschampion':
       $message['from'] = 'leadership@campuschampions.org';
@@ -323,7 +322,6 @@ function campuschampions_mail($key, &$message, $params) {
     case 'join-cc':
       $message['from'] = 'leadership@campuschampions.org';
       $message['subject'] = $params['title'];
-      ;
       $message['body'][] = $params['body'];
       break;
   }
@@ -349,7 +347,7 @@ function campuschampions_mail_alter(&$message) {
       // case 'status_canceled':
     case 'approve_campuschampion':
       $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed; delsp=yes';
-      foreach ($message['body'] as $key => &$body) {
+      foreach ($message['body'] as &$body) {
         $body = new FormattableMarkup($body, []);
       }
       break;
@@ -382,12 +380,12 @@ function campuschampions_redirect_to_profile_page_form_submit($form, &$form_stat
 }
 
 /**
- * Implements HOOK_views_data_export_row_alter().
+ * Implements hook_views_data_export_row_alter().
  *
- * Fill out data about the associated intstitution (Carnegie code).
+ * Fill out data about the associated institution (Carnegie code).
  */
 function campuschampions_views_data_export_row_alter(&$row, ResultRow $result, ViewExecutable $view) {
-  // Static cache for the Carnegie lookup instance and lat/lon data
+  // Static cache for the Carnegie lookup instance and lat/lon data.
   static $carnegie_db = NULL;
   static $org_locations = NULL;
 
@@ -395,7 +393,7 @@ function campuschampions_views_data_export_row_alter(&$row, ResultRow $result, V
 
     $cc = (string) $row['field_carnegie_code'];
 
-    $row['field_carnegie_code'] = t('');
+    $row['field_carnegie_code'] = '';
     $row['field_carnegie_code_location'] = '';
     $row['field_carnegie_code_classification'] = '';
     $row['field_carnegie_code_hbcu'] = '';
@@ -413,9 +411,10 @@ function campuschampions_views_data_export_row_alter(&$row, ResultRow $result, V
     $row['field_carnegie_code_lat'] = '';
     $row['field_carnegie_code_lon'] = '';
 
-    // Only get Carnegie data if a code exists - don't try to populate missing ones.
+    // Only get Carnegie data if a code exists - don't try to populate missing
+    // ones.
     if (!empty($cc)) {
-      // Initialize static caches
+      // Initialize static caches.
       if ($carnegie_db === NULL) {
         $carnegie_db = new CarnegieCodesLookup(\Drupal::database());
       }
@@ -473,13 +472,15 @@ function campuschampions_views_data_export_row_alter(&$row, ResultRow $result, V
         );
         $row['field_carnegie_code_type'] = CarnegieCodesLookup::type($row['field_carnegie_code_type_id']);
 
-        // Try to retrieve the LAT and LON from the ACCESS organization (with caching)
+        // Try to retrieve the LAT and LON from the ACCESS organization (with
+        // caching).
         if (isset($org_locations[$cc])) {
-          // Use cached values
+          // Use cached values.
           $row['field_carnegie_code_lat'] = $org_locations[$cc]['lat'];
           $row['field_carnegie_code_lon'] = $org_locations[$cc]['lon'];
-        } else {
-          // Look it up and cache it
+        }
+        else {
+          // Look it up and cache it.
           $nids = \Drupal::entityQuery('node')
             ->condition('type', 'access_organization')
             ->condition('field_carnegie_code', $cc, '=')
@@ -494,11 +495,12 @@ function campuschampions_views_data_export_row_alter(&$row, ResultRow $result, V
               $lon = $org->field_longitude ? $org->field_longitude->value : NULL;
               $row['field_carnegie_code_lat'] = $lat;
               $row['field_carnegie_code_lon'] = $lon;
-              // Cache for future rows
+              // Cache for future rows.
               $org_locations[$cc] = ['lat' => $lat, 'lon' => $lon];
             }
-          } else {
-            // Cache that we found nothing for this code
+          }
+          else {
+            // Cache that we found nothing for this code.
             $org_locations[$cc] = ['lat' => NULL, 'lon' => NULL];
           }
         }
@@ -523,7 +525,7 @@ function campuschampions_views_pre_view(ViewExecutable $view, $display_id, array
     $view_filters['field_domain_access_target_id']['value'] = [];
     $view_filters['field_domain_access_target_id']['value'][$domain] = $domain;
 
-    //field_domain_access_target_id
+    // field_domain_access_target_id.
     $view->display_handler->setOption('filters', $view_filters);
   }
 }
@@ -543,13 +545,13 @@ function campuschampions_preprocess_views_view(array &$variables) {
 /**
  * Validate Carnegie code field on user forms.
  */
-function campuschampions_user_form_validate(array &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
+function campuschampions_user_form_validate(array &$form, FormStateInterface $form_state) {
   $carnegie_code = $form_state->getValue('field_carnegie_code');
 
   if (!empty($carnegie_code) && !empty($carnegie_code[0]['value'])) {
     $code = $carnegie_code[0]['value'];
 
-    // Validate that the Carnegie code exists in the database
+    // Validate that the Carnegie code exists in the database.
     $query = \Drupal::database()
       ->select('carnegie_codes', 'cc')
       ->fields('cc', ['unitid'])
@@ -572,9 +574,10 @@ function campuschampions_cron() {
   $currentTime = \Drupal::time()->getCurrentTime();
   $lastRun = \Drupal::state()->get('cc_stats_last_update', 0);
 
-  // Run if it's been more than 24 hours since last update
+  // Run if it's been more than 24 hours since last update.
   $secondsSinceLastRun = $currentTime - $lastRun;
-  $hoursInterval = 24; // Update every 24 hours
+  // Update every 24 hours.
+  $hoursInterval = 24;
 
   if ($secondsSinceLastRun >= ($hoursInterval * 3600)) {
     \Drupal::logger('campuschampions')->info('Updating Campus Champions stats via cron');

--- a/web/modules/custom/campuschampions/campuschampions.module
+++ b/web/modules/custom/campuschampions/campuschampions.module
@@ -16,6 +16,8 @@ use Drupal\node\NodeInterface;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
 use Drupal\views\ResultRow;
+use Drupal\webform\Entity\WebformSubmission;
+use Drupal\webform\WebformSubmissionInterface;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -50,10 +52,8 @@ function campuschampions_form_alter(&$form, &$form_state, $form_id) {
 
     $form['elements']['carnegie_classification']['#autocomplete_route_name'] = 'campuschampions.autocomplete';
 
-    // Reorder form.
-    $user_institution = $form['elements']['user_institution'];
-    unset($form['elements']['user_institution']);
-    $form['elements']['user_institution'] = $user_institution;
+    // Reveal institution + Carnegie fields when "Other" org is selected.
+    $form['#attached']['library'][] = 'campuschampions/join-org-toggle';
 
     if ($form['#validate'] != 'validate_form') {
       $form['#validate'][] = 'validate_form';
@@ -136,6 +136,73 @@ function campuschampions_form_alter(&$form, &$form_state, $form_id) {
       . '</div>';
     unset($element);
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave() for webform_submission.
+ *
+ * On the Join Campus Champions form the applicant selects their ACCESS
+ * Organization directly. When that organization is a real one (not "Other"),
+ * copy its Carnegie code onto the submission's carnegie_classification value
+ * so downstream consumers (the applications export, reporting) keep reading a
+ * populated code without a lossy name-to-org lookup. When "Other" is chosen
+ * the applicant enters the code by hand, so it is left as submitted.
+ */
+function campuschampions_webform_submission_presave(WebformSubmissionInterface $submission) {
+  if ($submission->getWebform()->id() !== 'join_campus_champions') {
+    return;
+  }
+  $org_id = $submission->getElementData('field_access_organization');
+  // "Other" (node 3695) has no real code; keep the hand-entered value.
+  if (empty($org_id) || (string) $org_id === '3695') {
+    return;
+  }
+  $org = Node::load($org_id);
+  if ($org instanceof NodeInterface && $org->hasField('field_carnegie_code')) {
+    $code = $org->get('field_carnegie_code')->value;
+    // A "0" placeholder means the org has no applicable Carnegie code (a
+    // company or a non-US institution); store it as-is, matching the field.
+    $submission->setElementData('carnegie_classification', (string) $code);
+  }
+}
+
+/**
+ * Sets the status of a champion's approved Join Campus Champions submissions.
+ *
+ * The submission owner (uid) is the authoritative link to the champion's
+ * account — the approval action reconciles it, and update 9001 backfilled it
+ * for historical rows — so this keys on uid rather than the mutable email or
+ * username stored in the submission data.
+ *
+ * @param int $uid
+ *   The champion's account id.
+ * @param string $new_status
+ *   The status to set (e.g. 'superseded', 'removed').
+ * @param int|null $exclude_sid
+ *   A submission id to leave untouched (the just-approved one when
+ *   superseding its predecessors).
+ *
+ * @return int
+ *   The number of submissions updated.
+ */
+function _campuschampions_set_champion_submission_status(int $uid, string $new_status, ?int $exclude_sid = NULL): int {
+  $query = \Drupal::entityTypeManager()->getStorage('webform_submission')->getQuery()
+    ->condition('webform_id', 'join_campus_champions')
+    ->condition('uid', $uid)
+    ->accessCheck(FALSE);
+  if ($exclude_sid !== NULL) {
+    $query->condition('sid', $exclude_sid, '<>');
+  }
+  $sids = $query->execute();
+  $count = 0;
+  foreach (WebformSubmission::loadMultiple($sids) as $submission) {
+    if ($submission->getElementData('status') === 'approved') {
+      $submission->setElementData('status', $new_status);
+      $submission->resave();
+      $count++;
+    }
+  }
+  return $count;
 }
 
 if (!function_exists('validate_form')) {

--- a/web/modules/custom/campuschampions/campuschampions.module
+++ b/web/modules/custom/campuschampions/campuschampions.module
@@ -529,6 +529,18 @@ function campuschampions_views_pre_view(ViewExecutable $view, $display_id, array
 }
 
 /**
+ * Implements hook_preprocess_views_view().
+ *
+ * Attach the module CSS to the applications admin view so its exposed filters
+ * render on one compact row.
+ */
+function campuschampions_preprocess_views_view(array &$variables) {
+  if (($variables['view']->id() ?? NULL) === 'cc_applications') {
+    $variables['#attached']['library'][] = 'campuschampions/assets';
+  }
+}
+
+/**
  * Validate Carnegie code field on user forms.
  */
 function campuschampions_user_form_validate(array &$form, \Drupal\Core\Form\FormStateInterface $form_state) {

--- a/web/modules/custom/campuschampions/campuschampions.module
+++ b/web/modules/custom/campuschampions/campuschampions.module
@@ -48,6 +48,20 @@ function campuschampions_form_alter(&$form, &$form_state, $form_id) {
       $form['elements']['user_first_name']['#attributes'] = ['readonly' => 'readonly'];
       $form['elements']['user_last_name']['#attributes'] = ['readonly' => 'readonly'];
       $form['elements']['user_email']['#attributes'] = ['readonly' => 'readonly'];
+
+      // A returning champion (already approved) is updating their membership,
+      // not joining. Retitle the form and add a short explainer. Pending
+      // applicants never reach this form — they are redirected to edit their
+      // in-review submission — so only new vs. approved apply here.
+      $is_champion = $account->hasField('field_is_cc') && (bool) $account->get('field_is_cc')->value;
+      if ($is_champion) {
+        $form['#title'] = t('Update Your Campus Champions Membership');
+        $form['elements']['returning_champion_intro'] = [
+          '#type' => 'webform_markup',
+          '#markup' => '<p>' . t("You're already a Campus Champion. Use this form to update your membership, for example if you've changed institutions. Select your new organization below and submit a new Letter of Collaboration from that institution. Your information will update once your new application is approved.") . '</p>',
+          '#weight' => -100,
+        ];
+      }
     }
 
     $form['elements']['carnegie_classification']['#autocomplete_route_name'] = 'campuschampions.autocomplete';

--- a/web/modules/custom/campuschampions/campuschampions.module
+++ b/web/modules/custom/campuschampions/campuschampions.module
@@ -81,8 +81,8 @@ function campuschampions_form_alter(&$form, &$form_state, $form_id) {
     // Reveal institution + Carnegie fields when "Other" org is selected.
     $form['#attached']['library'][] = 'campuschampions/join-org-toggle';
 
-    if ($form['#validate'] != 'validate_form') {
-      $form['#validate'][] = 'validate_form';
+    if ($form['#validate'] != 'campuschampions_join_form_validate') {
+      $form['#validate'][] = 'campuschampions_join_form_validate';
     }
   }
 
@@ -104,8 +104,8 @@ function campuschampions_form_alter(&$form, &$form_state, $form_id) {
 
     // Don't allow people to join the Campus Champions field unless the is_cc
     // field is checked.
-    if ($form['#validate'] != 'validate_user_form') {
-      $form['#validate'][] = 'validate_user_form';
+    if ($form['#validate'] != 'campuschampions_user_region_validate') {
+      $form['#validate'][] = 'campuschampions_user_region_validate';
     }
   }
 
@@ -232,12 +232,12 @@ function _campuschampions_set_champion_submission_status(int $uid, string $new_s
   return $count;
 }
 
-if (!function_exists('validate_form')) {
+if (!function_exists('campuschampions_join_form_validate')) {
 
   /**
    * Validates the Campus Champions join form for duplicate email/username.
    */
-  function validate_form(array &$form, FormStateInterface $form_state) {
+  function campuschampions_join_form_validate(array &$form, FormStateInterface $form_state) {
     $user_email = $form_state->getValue('user_email');
     $username = $form_state->getValue('username');
 
@@ -264,17 +264,12 @@ if (!function_exists('validate_form')) {
 
 }
 
-/**
- * Implements validate_user_form().
- *
- * Require is_cc field to assign Campus Champions Program.
- */
-if (!function_exists('validate_user_form')) {
+if (!function_exists('campuschampions_user_region_validate')) {
 
   /**
    * Requires the is_cc field before assigning the Campus Champions program.
    */
-  function validate_user_form(array &$form, FormStateInterface $form_state) {
+  function campuschampions_user_region_validate(array &$form, FormStateInterface $form_state) {
     $programs = $form_state->getValue('field_region');
     $is_cc = $form_state->getValue('field_is_cc');
     // 572 is Campus Champions

--- a/web/modules/custom/campuschampions/campuschampions.module
+++ b/web/modules/custom/campuschampions/campuschampions.module
@@ -49,6 +49,17 @@ function campuschampions_form_alter(&$form, &$form_state, $form_id) {
       $form['elements']['user_last_name']['#attributes'] = ['readonly' => 'readonly'];
       $form['elements']['user_email']['#attributes'] = ['readonly' => 'readonly'];
 
+      // Prefill the organization from the account when one is set, so a
+      // returning user starts from their current organization (and can change
+      // it). Left editable, unlike the locked identity fields above.
+      if ($account->hasField('field_access_organization')
+        && !$account->get('field_access_organization')->isEmpty()) {
+        $org = $account->get('field_access_organization')->entity;
+        if ($org) {
+          $form['elements']['field_access_organization']['#default_value'] = $org;
+        }
+      }
+
       // A returning champion (already approved) is updating their membership,
       // not joining. Retitle the form and add a short explainer. Pending
       // applicants never reach this form — they are redirected to edit their

--- a/web/modules/custom/campuschampions/campuschampions.services.yml
+++ b/web/modules/custom/campuschampions/campuschampions.services.yml
@@ -2,3 +2,12 @@ services:
   cc.getStats:
     class: Drupal\campuschampions\Plugin\StoreStats
     arguments: ['@renderer']
+  campuschampions.join_form_redirect_subscriber:
+    class: Drupal\campuschampions\EventSubscriber\JoinFormRedirectSubscriber
+    arguments: ['@current_user', '@entity_type.manager', '@current_route_match']
+    tags:
+      - { name: event_subscriber }
+  campuschampions.title_resolver:
+    class: Drupal\campuschampions\NonRecursiveTitleResolver
+    decorates: title_resolver
+    arguments: ['@campuschampions.title_resolver.inner']

--- a/web/modules/custom/campuschampions/campuschampions.views.inc
+++ b/web/modules/custom/campuschampions/campuschampions.views.inc
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Views integration for the campuschampions module.
+ */
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function campuschampions_views_data_alter(array &$data) {
+  $data['webform_submission']['cc_duplicate_name'] = [
+    'title' => t('Duplicate applicant name'),
+    'help' => t('Limit results to submissions whose applicant name appears on more than one submission of the same webform.'),
+    'filter' => [
+      'field' => 'sid',
+      'label' => t('Duplicate names only'),
+      'id' => 'campuschampions_duplicate_submission_name',
+    ],
+  ];
+}

--- a/web/modules/custom/campuschampions/campuschampions.views.inc
+++ b/web/modules/custom/campuschampions/campuschampions.views.inc
@@ -18,4 +18,14 @@ function campuschampions_views_data_alter(array &$data) {
       'id' => 'campuschampions_duplicate_submission_name',
     ],
   ];
+
+  $data['webform_submission']['cc_applicant_search'] = [
+    'title' => t('Applicant search'),
+    'help' => t('Free-text search matching a term against the applicant first name, last name, or email.'),
+    'filter' => [
+      'field' => 'sid',
+      'label' => t('Search'),
+      'id' => 'campuschampions_applicant_search',
+    ],
+  ];
 }

--- a/web/modules/custom/campuschampions/config/schema/campuschampions.views.schema.yml
+++ b/web/modules/custom/campuschampions/config/schema/campuschampions.views.schema.yml
@@ -1,0 +1,17 @@
+views.filter.campuschampions_duplicate_submission_name:
+  type: views_filter
+  label: 'Duplicate applicant name'
+  mapping:
+    webform_id:
+      type: string
+      label: 'Webform ID'
+    first_name_element:
+      type: string
+      label: 'First name element key'
+    last_name_element:
+      type: string
+      label: 'Last name element key'
+
+views.filter_value.campuschampions_duplicate_submission_name:
+  type: string
+  label: 'Duplicate applicant name'

--- a/web/modules/custom/campuschampions/css/campuschampions-theme.css
+++ b/web/modules/custom/campuschampions/css/campuschampions-theme.css
@@ -45,20 +45,40 @@
 
 /*
  * Compact the cc-applications exposed filters: lay Search, Status, and
- * Duplicate on one wrapping row with the submit/reset buttons, instead of
- * stacking each filter full-width. Scoped to this view's exposed form (id is
- * view-id + display-id) so other exposed forms are untouched.
+ * Duplicate on one wrapping row instead of stacking each full-width. Scoped to
+ * this view's exposed form (id is view-id + display-id) so other exposed forms
+ * are untouched.
  */
 #views-exposed-form-cc-applications-page-1 {
     display: flex;
     flex-wrap: wrap;
-    align-items: flex-end;
-    gap: 0.75rem 1rem;
-}
-#views-exposed-form-cc-applications-page-1 .form-item,
-#views-exposed-form-cc-applications-page-1 .form-actions {
-    margin: 0;
+    /* Align rows by the top so the labels line up regardless of how many lines
+       each filter's help text runs to. */
+    align-items: flex-start;
+    gap: 0.5rem 1.5rem;
 }
 #views-exposed-form-cc-applications-page-1 .form-item {
-    flex: 0 1 auto;
+    /* Consistent column width so the inputs align in a tidy grid; each still
+       shrinks on narrow viewports. */
+    flex: 0 1 20rem;
+    margin: 0;
+}
+/* The Apply button carries no label/help, so nudge it down to sit level with
+   the inputs rather than the labels. */
+#views-exposed-form-cc-applications-page-1 .form-actions {
+    margin: 0;
+    align-self: flex-end;
+}
+/* Tame the per-filter help text so it doesn't dominate the compact row. */
+#views-exposed-form-cc-applications-page-1 .form-item .description {
+    font-size: 0.85em;
+    margin-top: 0.15rem;
+}
+
+/*
+ * The VBO action select lives in the results form (not the exposed form) and
+ * renders full-width by default. Constrain it to match the filter columns.
+ */
+#views-form-cc-applications-page-1 .form-item-action {
+    max-width: 24rem;
 }

--- a/web/modules/custom/campuschampions/css/campuschampions-theme.css
+++ b/web/modules/custom/campuschampions/css/campuschampions-theme.css
@@ -58,16 +58,54 @@
     gap: 0.5rem 1.5rem;
 }
 #views-exposed-form-cc-applications-page-1 .form-item {
-    /* Consistent column width so the inputs align in a tidy grid; each still
-       shrinks on narrow viewports. */
-    flex: 0 1 20rem;
+    /* Shrink-to-fit columns so all three filters plus the Apply button stay on
+       one row on a typical admin viewport; each still has a comfortable base
+       width and wraps only when genuinely narrow. */
+    flex: 1 1 14rem;
+    max-width: 22rem;
     margin: 0;
 }
-/* The Apply button carries no label/help, so nudge it down to sit level with
-   the inputs rather than the labels. */
+/* Reserve the same vertical space for every filter's label so the input below
+   it starts at the same Y across columns — otherwise a label with different
+   height or margin pushes its control down and the Search box and Status select
+   drift out of line. The checkbox item is excluded: its label sits beside the
+   box, not above it (see below). */
+#views-exposed-form-cc-applications-page-1 .form-item:not(.form-check) > label {
+    display: block;
+    min-height: 1.5rem;
+    margin: 0 0 0.5rem;
+    line-height: 1.5;
+}
+/* Lay the Duplicate-names checkbox and its label on one line. */
+#views-exposed-form-cc-applications-page-1 .form-check .form-checkbox {
+    float: none;
+    margin: 0 0.4rem 0 0;
+    vertical-align: middle;
+}
+#views-exposed-form-cc-applications-page-1 .form-check > label {
+    display: inline;
+    vertical-align: middle;
+}
+/* The Apply button carries no label/help. Align it to the top of the row (with
+   the labels) and push it down by roughly one label's height so it sits level
+   with the input boxes rather than dropping to the bottom of the tallest
+   column (the checkbox column has no input, so flex-end lands too low). */
 #views-exposed-form-cc-applications-page-1 .form-actions {
+    flex: 0 0 auto;
     margin: 0;
-    align-self: flex-end;
+    align-self: flex-start;
+    margin-top: 1.9rem;
+}
+/* Normalise the input controls so the Search box and the Status select are the
+   same height on the row. The theme sizes the select taller than the text
+   input by default, so pin both to one height with matching vertical padding. */
+#views-exposed-form-cc-applications-page-1 .form-text,
+#views-exposed-form-cc-applications-page-1 .form-select {
+    height: 2.75rem;
+    line-height: 1.5;
+    padding-top: 0.375rem;
+    padding-bottom: 0.375rem;
+    box-sizing: border-box;
 }
 /* Tame the per-filter help text so it doesn't dominate the compact row. */
 #views-exposed-form-cc-applications-page-1 .form-item .description {
@@ -76,9 +114,33 @@
 }
 
 /*
- * The VBO action select lives in the results form (not the exposed form) and
- * renders full-width by default. Constrain it to match the filter columns.
+ * VBO action row: put the "Action" select and its "Apply to selected items"
+ * button on one line, and stop the select rendering full-width. The select and
+ * button are siblings under the results form.
  */
+/* Lay the Action select and its "Apply to selected items" button on one row,
+   aligned by their bottom edges. Flexbox on the shared wrapper aligns the
+   controls directly, so the "Action" label stacked above the select no longer
+   throws the button off. */
+#views-form-cc-applications-page-1 #vbo-action-form-wrapper {
+    display: flex;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
 #views-form-cc-applications-page-1 .form-item-action {
     max-width: 24rem;
+    margin: 0;
+}
+#views-form-cc-applications-page-1 #vbo-action-form-wrapper .form-actions {
+    margin: 0;
+}
+/* The submit button carries a 10px bottom margin that lifts it off the wrapper
+   bottom, leaving it above the select. Drop it so their bottom edges match. */
+#views-form-cc-applications-page-1 #vbo-action-form-wrapper .form-submit {
+    margin-bottom: 0;
+}
+/* Give the results table room to breathe below the action row. */
+#views-form-cc-applications-page-1 .table-responsive {
+    margin-top: 1.5rem;
 }

--- a/web/modules/custom/campuschampions/css/campuschampions-theme.css
+++ b/web/modules/custom/campuschampions/css/campuschampions-theme.css
@@ -42,3 +42,23 @@
 .cc-num {
     font-size: 36px;
 }
+
+/*
+ * Compact the cc-applications exposed filters: lay Search, Status, and
+ * Duplicate on one wrapping row with the submit/reset buttons, instead of
+ * stacking each filter full-width. Scoped to this view's exposed form (id is
+ * view-id + display-id) so other exposed forms are untouched.
+ */
+#views-exposed-form-cc-applications-page-1 {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 0.75rem 1rem;
+}
+#views-exposed-form-cc-applications-page-1 .form-item,
+#views-exposed-form-cc-applications-page-1 .form-actions {
+    margin: 0;
+}
+#views-exposed-form-cc-applications-page-1 .form-item {
+    flex: 0 1 auto;
+}

--- a/web/modules/custom/campuschampions/js/join-org-toggle.js
+++ b/web/modules/custom/campuschampions/js/join-org-toggle.js
@@ -1,0 +1,84 @@
+/**
+ * @file
+ * Reveals the institution and Carnegie fields on the Join Campus Champions
+ * form when the applicant selects the "Other" organization (node 3695).
+ *
+ * Webform #states cannot reliably match an entity_autocomplete value, whose
+ * rendered value is a label like "Other (3695)" rather than the bare node id,
+ * so this mirrors the detection used by user_profiles/organization-toggle.
+ */
+(function ($, Drupal, once) {
+  'use strict';
+
+  Drupal.behaviors.ccJoinOrgToggle = {
+    attach: function (context) {
+      once('cc-join-org-toggle', '[name="field_access_organization"]', context).forEach(function (element) {
+        var $org = $(element);
+        var $institution = $('#edit-user-institution').closest('.js-form-wrapper, fieldset').first();
+        var $carnegie = $('[name="carnegie_classification"]').closest('.js-form-item, .form-item').first();
+
+        function isOther() {
+          var v = $org.val();
+          return !!v && (v === '3695' || v.indexOf('3695') !== -1);
+        }
+
+        function toggle() {
+          if (isOther()) {
+            $institution.show();
+            $carnegie.show();
+            $carnegie.find('input').prop('required', true);
+          }
+          else {
+            $institution.hide();
+            $carnegie.hide();
+            $carnegie.find('input').prop('required', false);
+          }
+        }
+
+        toggle();
+        $org.on('change keyup input autocompleteselect autocompletechange', function () {
+          setTimeout(toggle, 100);
+        });
+      });
+
+      // In the "Other" flow, turn the institution name into a type-ahead
+      // against the Carnegie institution list. Selecting a suggestion keeps
+      // the institution name in the field and fills the Carnegie code from the
+      // chosen row. Free text is still allowed for institutions not in the
+      // list (international schools, companies); those simply leave the code
+      // blank, which is correct.
+      once('cc-institution-carnegie', '[name="institution_name"]', context).forEach(function (element) {
+        var $institution = $(element);
+
+        // Carnegie is derived from the institution selection in this flow, so
+        // any edit to the institution name invalidates a previously filled
+        // code. Clear it on every change; a fresh selection refills it. This
+        // prevents a stale code from a prior pick sticking to a new, unmatched
+        // institution.
+        $institution.on('input change', function () {
+          $('[name="carnegie_classification"]').val('');
+        });
+
+        $institution.autocomplete({
+          minLength: 3,
+          source: function (request, response) {
+            $.getJSON('/autocomplete/carnegiecode', { q: request.term }, function (rows) {
+              response((rows || []).map(function (r) {
+                return { label: r.label, value: r.label, code: r.value };
+              }));
+            });
+          },
+          select: function (event, ui) {
+            // Defer so the clear-on-change handler (which jQuery UI may fire
+            // while writing the selected value) runs first, then set the code.
+            var code = ui.item.code;
+            setTimeout(function () {
+              $('[name="carnegie_classification"]').val(code);
+            }, 0);
+          },
+        });
+      });
+    }
+  };
+
+})(jQuery, Drupal, once);

--- a/web/modules/custom/campuschampions/src/EventSubscriber/JoinFormRedirectSubscriber.php
+++ b/web/modules/custom/campuschampions/src/EventSubscriber/JoinFormRedirectSubscriber.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\campuschampions\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Redirects non-admins to their existing Join Campus Champions submission.
+ */
+class JoinFormRedirectSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The webform that is guarded by this subscriber.
+   */
+  const WEBFORM_ID = 'join_campus_champions';
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a JoinFormRedirectSubscriber object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   */
+  public function __construct(AccountInterface $current_user, EntityTypeManagerInterface $entity_type_manager, RouteMatchInterface $route_match) {
+    $this->currentUser = $current_user;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // Run after the router has set the route match, before the controller.
+    $events[KernelEvents::REQUEST][] = ['onRequest', 30];
+    return $events;
+  }
+
+  /**
+   * Redirects to the user's previous submission, when one exists.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   The request event.
+   */
+  public function onRequest(RequestEvent $event) {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    // Only act on the canonical Join Campus Champions form page.
+    if ($this->routeMatch->getRouteName() !== 'entity.webform.canonical') {
+      return;
+    }
+    $webform = $this->routeMatch->getParameter('webform');
+    if (!$webform || $webform->id() !== self::WEBFORM_ID) {
+      return;
+    }
+
+    // Administrators keep full access to the blank form.
+    if ($this->currentUser->isAnonymous() || in_array('administrator', $this->currentUser->getRoles(), TRUE)) {
+      return;
+    }
+
+    $sids = $this->entityTypeManager->getStorage('webform_submission')->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('webform_id', self::WEBFORM_ID)
+      ->condition('uid', $this->currentUser->id())
+      ->sort('sid', 'DESC')
+      ->range(0, 1)
+      ->execute();
+    if (empty($sids)) {
+      // No previous submission: let them fill out a new form.
+      return;
+    }
+
+    $url = Url::fromRoute('entity.webform.user.submission.edit', [
+      'webform' => self::WEBFORM_ID,
+      'webform_submission' => reset($sids),
+    ]);
+    $event->setResponse(new RedirectResponse($url->toString()));
+  }
+
+}

--- a/web/modules/custom/campuschampions/src/EventSubscriber/JoinFormRedirectSubscriber.php
+++ b/web/modules/custom/campuschampions/src/EventSubscriber/JoinFormRedirectSubscriber.php
@@ -92,21 +92,31 @@ class JoinFormRedirectSubscriber implements EventSubscriberInterface {
       return;
     }
 
+    // Redirect only when they have a submission still awaiting review, so a
+    // second application cannot stack while one is pending. An approved
+    // champion may start a fresh application (e.g. to change organizations),
+    // which then goes through normal approval.
     $sids = $this->entityTypeManager->getStorage('webform_submission')->getQuery()
       ->accessCheck(FALSE)
       ->condition('webform_id', self::WEBFORM_ID)
       ->condition('uid', $this->currentUser->id())
       ->sort('sid', 'DESC')
-      ->range(0, 1)
       ->execute();
-    if (empty($sids)) {
-      // No previous submission: let them fill out a new form.
+    $pending_sid = NULL;
+    foreach ($this->entityTypeManager->getStorage('webform_submission')->loadMultiple($sids) as $submission) {
+      if (($submission->getElementData('status') ?? 'new') === 'new') {
+        $pending_sid = $submission->id();
+        break;
+      }
+    }
+    if ($pending_sid === NULL) {
+      // No pending submission: let them fill out a new form.
       return;
     }
 
     $url = Url::fromRoute('entity.webform.user.submission.edit', [
       'webform' => self::WEBFORM_ID,
-      'webform_submission' => reset($sids),
+      'webform_submission' => $pending_sid,
     ]);
     $event->setResponse(new RedirectResponse($url->toString()));
   }

--- a/web/modules/custom/campuschampions/src/Form/RemoveChampionForm.php
+++ b/web/modules/custom/campuschampions/src/Form/RemoveChampionForm.php
@@ -161,6 +161,10 @@ class RemoveChampionForm extends FormBase {
 
       $user->save();
 
+      // Mark their approved Join Campus Champions submissions as removed so the
+      // applications list reflects that they are no longer in the program.
+      _campuschampions_set_champion_submission_status((int) $user->id(), 'removed');
+
       $this->messenger->addMessage($this->t('Removed @name from Campus Champions.', [
         '@name' => $user->getAccountName(),
       ]));

--- a/web/modules/custom/campuschampions/src/NonRecursiveTitleResolver.php
+++ b/web/modules/custom/campuschampions/src/NonRecursiveTitleResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\campuschampions;
+
+use Drupal\Core\Controller\TitleResolverInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Stops page title resolution from re-entering itself.
+ *
+ * Webform submission pages recurse infinitely when the token info cache is
+ * cold: mgv's page title global variable asks the title resolver for the
+ * title, WebformSubmission::label() runs that title through token replacement,
+ * building token info makes webform's hook render its "more" examples in
+ * isolation, that render runs template_preprocess_default_variables_alter,
+ * and mgv asks for the page title again -- until the call stack is exhausted.
+ *
+ * A title is never legitimately resolved while another one is still being
+ * resolved, so the nested call returns NULL and the cycle cannot start.
+ *
+ * @see \Drupal\mgv\Plugin\GlobalVariable\RawCurrentPageTitle::getValue()
+ * @see \Drupal\webform\Hook\WebformTokensHooks::renderMore()
+ * @see https://www.drupal.org/project/webform/issues/3309183
+ */
+class NonRecursiveTitleResolver implements TitleResolverInterface {
+
+  /**
+   * The decorated title resolver.
+   *
+   * @var \Drupal\Core\Controller\TitleResolverInterface
+   */
+  protected $inner;
+
+  /**
+   * Whether a title is currently being resolved.
+   *
+   * @var bool
+   */
+  protected $resolving = FALSE;
+
+  /**
+   * Constructs a NonRecursiveTitleResolver object.
+   *
+   * @param \Drupal\Core\Controller\TitleResolverInterface $inner
+   *   The decorated title resolver.
+   */
+  public function __construct(TitleResolverInterface $inner) {
+    $this->inner = $inner;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTitle(Request $request, Route $route) {
+    if ($this->resolving) {
+      return NULL;
+    }
+    $this->resolving = TRUE;
+    try {
+      return $this->inner->getTitle($request, $route);
+    }
+    finally {
+      $this->resolving = FALSE;
+    }
+  }
+
+}

--- a/web/modules/custom/campuschampions/src/Plugin/Action/ApproveCCAction.php
+++ b/web/modules/custom/campuschampions/src/Plugin/Action/ApproveCCAction.php
@@ -66,7 +66,7 @@ class ApproveCCAction extends ViewsBulkOperationsActionBase implements Container
     $plugin_definition,
     LoggerChannelFactoryInterface $logger_factory,
     MailManagerInterface $mail_manager,
-    MessengerInterface $messenger
+    MessengerInterface $messenger,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->loggerFactory = $logger_factory;
@@ -151,7 +151,7 @@ class ApproveCCAction extends ViewsBulkOperationsActionBase implements Container
       $user->addRole('research_computing_facilitator');
     }
 
-    $user->set('field_carnegie_code', $data['carnegie_classification']);
+    $user->set('field_carnegie_code', $data['carnegie_classification'] ?? NULL);
     $user->set('field_is_cc', 1);
 
     // Set the organization from the application. This is what makes an
@@ -275,7 +275,7 @@ class ApproveCCAction extends ViewsBulkOperationsActionBase implements Container
       return;
     }
 
-    $message = $this->t('An email notification has been sent to @email ', ['@email' => $to]);
+    $message = $this->t('An email notification has been sent to @email', ['@email' => $to]);
     $this->messenger->addMessage($message);
     $this->loggerFactory->get('mail-log')->notice($message);
   }

--- a/web/modules/custom/campuschampions/src/Plugin/Action/ApproveCCAction.php
+++ b/web/modules/custom/campuschampions/src/Plugin/Action/ApproveCCAction.php
@@ -151,7 +151,13 @@ class ApproveCCAction extends ViewsBulkOperationsActionBase implements Container
       $user->addRole('research_computing_facilitator');
     }
 
-    $user->set('field_carnegie_code', $data['carnegie_classification'] ?? NULL);
+    // Only write the Carnegie code when the application actually carries one.
+    // The webform only collects it for "Other" organizations; for every other
+    // org the key is absent, and blindly assigning NULL would blank a value the
+    // account may already hold. Mirrors the organization write below.
+    if (array_key_exists('carnegie_classification', $data)) {
+      $user->set('field_carnegie_code', $data['carnegie_classification']);
+    }
     $user->set('field_is_cc', 1);
 
     // Set the organization from the application. This is what makes an
@@ -188,21 +194,36 @@ class ApproveCCAction extends ViewsBulkOperationsActionBase implements Container
       }
     }
 
-    $user->save();
+    // These writes are not atomic: the account, the submission owner, and the
+    // superseding of prior applications each commit separately. If one throws
+    // partway, the record is left half-approved. Re-running the approval
+    // converges (every step is idempotent), but only if someone knows to do it
+    // — so on failure tell the admin on screen, not just the log.
+    try {
+      $user->save();
 
-    // Reconcile the submission to the resolved account. The applicant may have
-    // submitted anonymously or under a different account, so anchor this
-    // submission to the champion we just approved. Every later operation
-    // (supersede, removal, the join-form redirect) can then trust the uid.
-    if ((int) $webform_submission->getOwnerId() !== (int) $user->id()) {
-      $webform_submission->setOwnerId($user->id());
-      $webform_submission->resave();
+      // Reconcile the submission to the resolved account. The applicant may
+      // have submitted anonymously or under a different account, so anchor
+      // this submission to the champion we just approved. Every later
+      // operation (supersede, removal, the join-form redirect) trusts the uid.
+      if ((int) $webform_submission->getOwnerId() !== (int) $user->id()) {
+        $webform_submission->setOwnerId($user->id());
+        $webform_submission->resave();
+      }
+
+      // Supersede the champion's earlier approved applications so the current
+      // organization is unambiguous — the account holds the live org, and only
+      // this newly approved submission stays 'approved'.
+      _campuschampions_set_champion_submission_status((int) $user->id(), 'superseded', (int) $sid);
     }
-
-    // Supersede the champion's earlier approved applications so the current
-    // organization is unambiguous — the account holds the live org, and only
-    // this newly approved submission stays 'approved'.
-    _campuschampions_set_champion_submission_status((int) $user->id(), 'superseded', (int) $sid);
+    catch (\Exception $e) {
+      $this->loggerFactory->get('campuschampions')->error(
+        'Approval partially failed for submission @sid (user @uid): @message',
+        ['@sid' => $sid, '@uid' => $user->id(), '@message' => $e->getMessage()]
+      );
+      $this->messenger->addError($this->t('Approving @email did not fully complete and the record may be in a partial state. Please approve this application again — it is safe to re-run.', ['@email' => $user_email]));
+      return $this->t('Error: approval of @email did not complete. Re-run the approval.', ['@email' => $user_email]);
+    }
 
     $this->emailAccountNotification($user);
 

--- a/web/modules/custom/campuschampions/src/Plugin/Action/ApproveCCAction.php
+++ b/web/modules/custom/campuschampions/src/Plugin/Action/ApproveCCAction.php
@@ -154,6 +154,16 @@ class ApproveCCAction extends ViewsBulkOperationsActionBase implements Container
     $user->set('field_carnegie_code', $data['carnegie_classification']);
     $user->set('field_is_cc', 1);
 
+    // Set the organization from the application. This is what makes an
+    // approved change-of-institution application actually move the champion
+    // to their new organization. Only set it when the application names a
+    // real organization; leave the existing one untouched otherwise so a
+    // blank or "Other" submission never clears a good value.
+    $org_id = $data['field_access_organization'] ?? NULL;
+    if (!empty($org_id) && (string) $org_id !== '3695') {
+      $user->set('field_access_organization', $org_id);
+    }
+
     // Campus Champions Program ID.
     $cc_id = 572;
 
@@ -179,6 +189,20 @@ class ApproveCCAction extends ViewsBulkOperationsActionBase implements Container
     }
 
     $user->save();
+
+    // Reconcile the submission to the resolved account. The applicant may have
+    // submitted anonymously or under a different account, so anchor this
+    // submission to the champion we just approved. Every later operation
+    // (supersede, removal, the join-form redirect) can then trust the uid.
+    if ((int) $webform_submission->getOwnerId() !== (int) $user->id()) {
+      $webform_submission->setOwnerId($user->id());
+      $webform_submission->resave();
+    }
+
+    // Supersede the champion's earlier approved applications so the current
+    // organization is unambiguous — the account holds the live org, and only
+    // this newly approved submission stays 'approved'.
+    _campuschampions_set_champion_submission_status((int) $user->id(), 'superseded', (int) $sid);
 
     $this->emailAccountNotification($user);
 

--- a/web/modules/custom/campuschampions/src/Plugin/Action/SupersedeCCAction.php
+++ b/web/modules/custom/campuschampions/src/Plugin/Action/SupersedeCCAction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\campuschampions\Plugin\Action;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\views_bulk_operations\Action\ViewsBulkOperationsActionBase;
+use Drupal\webform\Entity\WebformSubmission;
+use Drupal\webform\WebformSubmissionForm;
+
+/**
+ * @Action(
+ *   id = "campuschampions_supersede",
+ *   label = @Translation("Mark as superseded"),
+ *   type = ""
+ * )
+ */
+class SupersedeCCAction extends ViewsBulkOperationsActionBase {
+
+  /**
+   * Mark a Campus Champion application as superseded.
+   *
+   * Approval already supersedes a champion's prior approved applications
+   * automatically. This action is the manual counterpart for the applications
+   * view: when an applicant has more than one approved submission, an admin
+   * keeps the current one and supersedes the older duplicate(s).
+   *
+   * {@inheritdoc}
+   */
+  public function execute(WebformSubmission $entity = NULL) {
+    $submission = WebformSubmission::load($entity->id());
+    $submission->setElementData('status', 'superseded');
+    WebformSubmissionForm::submitWebformSubmission($submission);
+    return $this->t('Campus Champion application(s) marked as superseded');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    return $object->access('update', $account, $return_as_object);
+  }
+
+}

--- a/web/modules/custom/campuschampions/src/Plugin/WebformHandler/CreateUserHandler.php
+++ b/web/modules/custom/campuschampions/src/Plugin/WebformHandler/CreateUserHandler.php
@@ -138,15 +138,20 @@ class CreateUserHandler extends WebformHandlerBase {
     $default_role = 'research_computing_facilitator';
     $carnegie_code = $data['carnegie_classification'];
 
-    $query = $this->database->select('carnegie_codes', 'cc');
-    $query->condition('cc.unitid', $carnegie_code, '=');
-    $query->fields('cc', ['instnm']);
-    $result = $query->execute();
-    $record = $result->fetch();
-    $institution = $record ? $record->instnm : '';
-
-    // Try to find a matching ACCESS Organization by institution name.
-    $access_org_id = $this->findAccessOrganization($institution);
+    // The applicant selects their ACCESS Organization directly on the form, so
+    // use that node id rather than deriving it from the Carnegie code. "Other"
+    // (node 3695) means the org is not in the list; fall back to matching the
+    // hand-entered institution name so those applicants still get linked when
+    // possible.
+    $access_org_id = $data['field_access_organization'] ?? NULL;
+    $institution = '';
+    if (empty($access_org_id) || (string) $access_org_id === '3695') {
+      $access_org_id = NULL;
+      $institution = $data['user_institution']['institution_name'] ?? '';
+      if ($institution !== '') {
+        $access_org_id = $this->findAccessOrganization($institution);
+      }
+    }
 
     /** @var \Drupal\user\Entity\User $user */
     $user = User::create();

--- a/web/modules/custom/campuschampions/src/Plugin/views/filter/ApplicantSearch.php
+++ b/web/modules/custom/campuschampions/src/Plugin/views/filter/ApplicantSearch.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Drupal\campuschampions\Plugin\views\filter;
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Attribute\ViewsFilter;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+
+/**
+ * Free-text "contains" search across an applicant's name and email elements.
+ *
+ * The applicant's first name, last name, and email live in separate rows of
+ * {webform_submission_data}. A stock per-element string filter can only match
+ * one of them, so an admin searching "jane smith" against the last-name column
+ * finds nothing. This filter matches the term against any of the configured
+ * elements at once, so a single exposed box finds the applicant by first name,
+ * last name, or email.
+ *
+ * @ingroup views_filter_handlers
+ */
+#[ViewsFilter('campuschampions_applicant_search')]
+class ApplicantSearch extends FilterPluginBase {
+
+  /**
+   * This filter is exposed as a free-text box, not an operator dropdown.
+   *
+   * @var bool
+   */
+  // phpcs:ignore
+  public $no_operator = TRUE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['webform_id'] = ['default' => 'join_campus_champions'];
+    // Element keys searched, comma-separated so the value needs no custom
+    // config schema entry.
+    $options['search_elements'] = ['default' => 'user_first_name,user_last_name,user_email'];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+
+    $form['webform_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Webform ID'),
+      '#description' => $this->t('Machine name of the webform whose submissions are searched.'),
+      '#default_value' => $this->options['webform_id'],
+      '#required' => TRUE,
+    ];
+    $form['search_elements'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search element keys'),
+      '#description' => $this->t('Comma-separated submission element keys to search, e.g. user_first_name,user_last_name,user_email.'),
+      '#default_value' => $this->options['search_elements'],
+      '#required' => TRUE,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function valueForm(&$form, FormStateInterface $form_state) {
+    $form['value'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search'),
+      '#size' => 30,
+      '#default_value' => $this->value,
+    ];
+  }
+
+  /**
+   * Returns the configured element keys as a clean list.
+   *
+   * @return string[]
+   *   Element machine names, trimmed with empties removed.
+   */
+  protected function getSearchElements() {
+    $elements = array_map('trim', explode(',', (string) $this->options['search_elements']));
+    return array_values(array_filter($elements, 'strlen'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // An empty exposed box must not filter anything out.
+    $term = is_array($this->value) ? reset($this->value) : $this->value;
+    $term = trim((string) $term);
+    if ($term === '') {
+      return;
+    }
+    $elements = $this->getSearchElements();
+    if (!$elements) {
+      return;
+    }
+
+    $this->ensureMyTable();
+
+    // Placeholders are namespaced by handler id so the filter can appear more
+    // than once in one view without colliding.
+    $suffix = preg_replace('/[^a-z0-9_]/', '_', strtolower($this->options['id']));
+    $wid = ':cc_search_wid_' . $suffix;
+    $pat = ':cc_search_pat_' . $suffix;
+
+    $like = '%' . Database::getConnection()->escapeLike($term) . '%';
+    $args = [
+      $wid => $this->options['webform_id'],
+      $pat => $like,
+    ];
+    $name_placeholders = [];
+    foreach ($elements as $i => $element) {
+      $ph = ':cc_search_el_' . $suffix . '_' . $i;
+      $name_placeholders[] = $ph;
+      $args[$ph] = $element;
+    }
+    $name_in = implode(', ', $name_placeholders);
+
+    // A submission matches when any searched element contains the term.
+    $sql = <<<SQL
+{$this->tableAlias}.sid IN (
+  SELECT d.sid
+  FROM {webform_submission_data} d
+  INNER JOIN {webform_submission} s ON s.sid = d.sid
+  WHERE s.webform_id = $wid
+    AND d.name IN ($name_in)
+    AND LOWER(d.value) LIKE LOWER($pat)
+)
+SQL;
+
+    $this->query->addWhereExpression($this->options['group'], $sql, $args);
+  }
+
+}

--- a/web/modules/custom/campuschampions/src/Plugin/views/filter/ApplicantSearch.php
+++ b/web/modules/custom/campuschampions/src/Plugin/views/filter/ApplicantSearch.php
@@ -92,13 +92,23 @@ class ApplicantSearch extends FilterPluginBase {
    */
   public function query() {
     // An empty exposed box must not filter anything out.
-    $term = is_array($this->value) ? reset($this->value) : $this->value;
-    $term = trim((string) $term);
-    if ($term === '') {
+    $raw = is_array($this->value) ? reset($this->value) : $this->value;
+    $raw = trim((string) $raw);
+    if ($raw === '') {
       return;
     }
     $elements = $this->getSearchElements();
     if (!$elements) {
+      return;
+    }
+
+    // Split on whitespace so a "First Last" query matches an applicant whose
+    // first and last name live in separate submission-data rows. Each term must
+    // match somewhere across the searched elements (term ORs over elements) and
+    // all terms must match (terms AND together), so "kanin bender" finds the
+    // Kanin / Bender applicant and order does not matter.
+    $terms = preg_split('/\s+/', $raw, -1, PREG_SPLIT_NO_EMPTY);
+    if (!$terms) {
       return;
     }
 
@@ -108,13 +118,11 @@ class ApplicantSearch extends FilterPluginBase {
     // than once in one view without colliding.
     $suffix = preg_replace('/[^a-z0-9_]/', '_', strtolower($this->options['id']));
     $wid = ':cc_search_wid_' . $suffix;
-    $pat = ':cc_search_pat_' . $suffix;
+    $connection = Database::getConnection();
 
-    $like = '%' . Database::getConnection()->escapeLike($term) . '%';
-    $args = [
-      $wid => $this->options['webform_id'],
-      $pat => $like,
-    ];
+    $args = [$wid => $this->options['webform_id']];
+
+    // Element-name placeholders are shared across every term's subquery.
     $name_placeholders = [];
     foreach ($elements as $i => $element) {
       $ph = ':cc_search_el_' . $suffix . '_' . $i;
@@ -123,8 +131,12 @@ class ApplicantSearch extends FilterPluginBase {
     }
     $name_in = implode(', ', $name_placeholders);
 
-    // A submission matches when any searched element contains the term.
-    $sql = <<<SQL
+    // One correlated subquery per term; AND them so all terms must be found.
+    $term_clauses = [];
+    foreach ($terms as $ti => $term) {
+      $pat = ':cc_search_pat_' . $suffix . '_' . $ti;
+      $args[$pat] = '%' . $connection->escapeLike($term) . '%';
+      $term_clauses[] = <<<SQL
 {$this->tableAlias}.sid IN (
   SELECT d.sid
   FROM {webform_submission_data} d
@@ -134,7 +146,9 @@ class ApplicantSearch extends FilterPluginBase {
     AND LOWER(d.value) LIKE LOWER($pat)
 )
 SQL;
+    }
 
+    $sql = '(' . implode(' AND ', $term_clauses) . ')';
     $this->query->addWhereExpression($this->options['group'], $sql, $args);
   }
 

--- a/web/modules/custom/campuschampions/src/Plugin/views/filter/ApplicantSearch.php
+++ b/web/modules/custom/campuschampions/src/Plugin/views/filter/ApplicantSearch.php
@@ -17,6 +17,13 @@ use Drupal\views\Plugin\views\filter\FilterPluginBase;
  * elements at once, so a single exposed box finds the applicant by first name,
  * last name, or email.
  *
+ * Each term becomes a `sid IN (SELECT ... value LIKE '%term%')` subquery. The
+ * leading-wildcard LIKE cannot use an index, so it scans the submission-data
+ * rows for this one webform. That is fine here: the Campus Champions
+ * application set is a few hundred submissions (about 600 searched data rows),
+ * an admin-only listing that grows slowly. If this ever backs a large form,
+ * revisit with a starts-with option or a search_api index.
+ *
  * @ingroup views_filter_handlers
  */
 #[ViewsFilter('campuschampions_applicant_search')]

--- a/web/modules/custom/campuschampions/src/Plugin/views/filter/DuplicateSubmissionName.php
+++ b/web/modules/custom/campuschampions/src/Plugin/views/filter/DuplicateSubmissionName.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\campuschampions\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Attribute\ViewsFilter;
+use Drupal\views\Plugin\views\filter\BooleanOperator;
+
+/**
+ * Filters webform submissions down to those sharing an applicant name.
+ *
+ * A submission is considered a duplicate when the combination of its first
+ * and last name elements — lowercased and trimmed — appears on at least one
+ * other submission of the same webform, regardless of submission status.
+ *
+ * @ingroup views_filter_handlers
+ */
+#[ViewsFilter('campuschampions_duplicate_submission_name')]
+class DuplicateSubmissionName extends BooleanOperator {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['webform_id'] = ['default' => 'join_campus_champions'];
+    $options['first_name_element'] = ['default' => 'user_first_name'];
+    $options['last_name_element'] = ['default' => 'user_last_name'];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValueOptions() {
+    $this->valueOptions = [
+      1 => $this->t('Duplicates only'),
+      0 => $this->t('Non-duplicates only'),
+    ];
+    return $this->valueOptions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+
+    $form['webform_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Webform ID'),
+      '#description' => $this->t('Machine name of the webform whose submissions are compared.'),
+      '#default_value' => $this->options['webform_id'],
+      '#required' => TRUE,
+    ];
+    $form['first_name_element'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('First name element key'),
+      '#default_value' => $this->options['first_name_element'],
+      '#required' => TRUE,
+    ];
+    $form['last_name_element'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Last name element key'),
+      '#default_value' => $this->options['last_name_element'],
+      '#required' => TRUE,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // '- Any -' never reaches query(); core skips the handler entirely. Only
+    // an explicit yes/no choice gets here.
+    if ($this->value === NULL || $this->value === '' || $this->value === []) {
+      return;
+    }
+
+    $this->ensureMyTable();
+    $operator = empty($this->value) ? 'NOT IN' : 'IN';
+
+    // Placeholders are namespaced by handler id so the filter can appear more
+    // than once in a single view without colliding.
+    $suffix = preg_replace('/[^a-z0-9_]/', '_', strtolower($this->options['id']));
+    $wid = ':cc_dup_wid_' . $suffix;
+    $first = ':cc_dup_first_' . $suffix;
+    $last = ':cc_dup_last_' . $suffix;
+
+    $name_expression = "CONCAT(LOWER(TRIM(f.value)), '|', LOWER(TRIM(l.value)))";
+    $inner_expression = "CONCAT(LOWER(TRIM(f2.value)), '|', LOWER(TRIM(l2.value)))";
+
+    $sql = <<<SQL
+{$this->tableAlias}.sid $operator (
+  SELECT s.sid
+  FROM {webform_submission} s
+  INNER JOIN {webform_submission_data} f ON f.sid = s.sid AND f.name = $first
+  INNER JOIN {webform_submission_data} l ON l.sid = s.sid AND l.name = $last
+  WHERE s.webform_id = $wid
+    AND $name_expression IN (
+      SELECT dupes.cc_dup_name FROM (
+        SELECT $inner_expression AS cc_dup_name
+        FROM {webform_submission} s2
+        INNER JOIN {webform_submission_data} f2 ON f2.sid = s2.sid AND f2.name = $first
+        INNER JOIN {webform_submission_data} l2 ON l2.sid = s2.sid AND l2.name = $last
+        WHERE s2.webform_id = $wid
+        GROUP BY $inner_expression
+        HAVING COUNT(DISTINCT s2.sid) > 1
+      ) dupes
+    )
+)
+SQL;
+
+    $this->query->addWhereExpression($this->options['group'], $sql, [
+      $wid => $this->options['webform_id'],
+      $first => $this->options['first_name_element'],
+      $last => $this->options['last_name_element'],
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function adminSummary() {
+    if ($this->isAGroup()) {
+      return $this->t('grouped');
+    }
+    if (!empty($this->options['exposed'])) {
+      return $this->t('exposed');
+    }
+    return empty($this->value) ? $this->t('Non-duplicates only') : $this->t('Duplicates only');
+  }
+
+}

--- a/web/modules/custom/campuschampions/src/Plugin/views/filter/DuplicateSubmissionName.php
+++ b/web/modules/custom/campuschampions/src/Plugin/views/filter/DuplicateSubmissionName.php
@@ -87,25 +87,20 @@ class DuplicateSubmissionName extends BooleanOperator {
     $first = ':cc_dup_first_' . $suffix;
     $last = ':cc_dup_last_' . $suffix;
 
-    // Collapse repeated whitespace as well as trimming, so "Bathiya" and
-    // "Bathiya " (or a double space) count as the same applicant.
+    // Lowercase and trim so trailing/leading whitespace and case don't split a
+    // match, e.g. "Bathiya" and "Bathiya ".
     $name_expression = "CONCAT(LOWER(TRIM(f.value)), '|', LOWER(TRIM(l.value)))";
     $inner_expression = "CONCAT(LOWER(TRIM(f2.value)), '|', LOWER(TRIM(l2.value)))";
 
-    // A duplicate that matters is the same name approved more than once — the
-    // supersede lifecycle already handles a normal reapply (old approved rows
-    // become superseded). Only count approved submissions on both sides so the
-    // view surfaces the genuine anomaly rather than every historical reapply.
-    $status_join = "INNER JOIN {webform_submission_data} st ON st.sid = s.sid AND st.name = 'status' AND st.value = 'approved'";
-    $inner_status_join = "INNER JOIN {webform_submission_data} st2 ON st2.sid = s2.sid AND st2.name = 'status' AND st2.value = 'approved'";
-
+    // Status-agnostic: a duplicate is any name appearing on more than one
+    // submission. Narrow to a specific status (e.g. approved) with the view's
+    // separate "Filter by Status" exposed filter rather than baking it in here.
     $sql = <<<SQL
 {$this->tableAlias}.sid $operator (
   SELECT s.sid
   FROM {webform_submission} s
   INNER JOIN {webform_submission_data} f ON f.sid = s.sid AND f.name = $first
   INNER JOIN {webform_submission_data} l ON l.sid = s.sid AND l.name = $last
-  $status_join
   WHERE s.webform_id = $wid
     AND $name_expression IN (
       SELECT dupes.cc_dup_name FROM (
@@ -113,7 +108,6 @@ class DuplicateSubmissionName extends BooleanOperator {
         FROM {webform_submission} s2
         INNER JOIN {webform_submission_data} f2 ON f2.sid = s2.sid AND f2.name = $first
         INNER JOIN {webform_submission_data} l2 ON l2.sid = s2.sid AND l2.name = $last
-        $inner_status_join
         WHERE s2.webform_id = $wid
         GROUP BY $inner_expression
         HAVING COUNT(DISTINCT s2.sid) > 1

--- a/web/modules/custom/campuschampions/src/Plugin/views/filter/DuplicateSubmissionName.php
+++ b/web/modules/custom/campuschampions/src/Plugin/views/filter/DuplicateSubmissionName.php
@@ -13,6 +13,15 @@ use Drupal\views\Plugin\views\filter\BooleanOperator;
  * and last name elements — lowercased and trimmed — appears on at least one
  * other submission of the same webform, regardless of submission status.
  *
+ * The filter has two faces. When configured in the Views UI (non-exposed) it
+ * behaves like the parent BooleanOperator: a 0/1/'All' value with the options
+ * from getValueOptions(). When exposed on the page it renders as a single
+ * checkbox whose value is only ever 1 (checked, show duplicates) or 'All'
+ * (unchecked, no filter) — the "Non-duplicates only" (0) state is unreachable.
+ * valueForm() branches on $form_state->get('exposed') to build each face, and
+ * adminSummary() only runs for the non-exposed one; keep those two branch
+ * conditions in sync if you touch either.
+ *
  * @ingroup views_filter_handlers
  */
 #[ViewsFilter('campuschampions_duplicate_submission_name')]
@@ -31,6 +40,11 @@ class DuplicateSubmissionName extends BooleanOperator {
 
   /**
    * {@inheritdoc}
+   *
+   * These options back the non-exposed (Views UI config) radios only. The
+   * exposed checkbox uses its own hardcoded label in valueForm() and never
+   * yields the 0 ("Non-duplicates only") state, so relabelling the exposed
+   * filter means editing valueForm(), not this list.
    */
   public function getValueOptions() {
     $this->valueOptions = [
@@ -70,15 +84,57 @@ class DuplicateSubmissionName extends BooleanOperator {
   /**
    * {@inheritdoc}
    */
+  protected function valueForm(&$form, FormStateInterface $form_state) {
+    // The only useful state is "show duplicates", so expose a single checkbox
+    // (checked = duplicates only, unchecked = no filter) rather than core's
+    // three-option select.
+    //
+    // Do NOT call parent::valueForm() on the exposed path: BooleanOperator
+    // back-fills $form_state user input from $this->value, which forces the
+    // checkbox to render checked. Build the checkbox from the actual request
+    // instead so its state matches acceptExposedInput().
+    if ($form_state->get('exposed')) {
+      $identifier = $this->options['expose']['identifier'];
+      $form['value'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Duplicate names only'),
+        '#default_value' => (bool) \Drupal::request()->query->get($identifier),
+        '#return_value' => 1,
+      ];
+      return;
+    }
+    parent::valueForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function acceptExposedInput($input) {
+    if (empty($this->options['exposed'])) {
+      return parent::acceptExposedInput($input);
+    }
+    // An unchecked checkbox submits nothing, but Views back-fills the exposed
+    // input from the stored default, so $input can carry a stale "on" value.
+    // Read the real submitted request parameter instead: it is present and
+    // truthy only when the box was actually checked. Absent (whether unchecked
+    // on submit or a fresh page load) always means "no filter".
+    $identifier = $this->options['expose']['identifier'];
+    $this->value = \Drupal::request()->query->get($identifier) ? 1 : 'All';
+    return $this->value === 1;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function query() {
-    // '- Any -' never reaches query(); core skips the handler entirely. Only
-    // an explicit yes/no choice gets here.
-    if ($this->value === NULL || $this->value === '' || $this->value === []) {
+    // Unchecked box (or '- Any -') means no filtering — show everything.
+    if (empty($this->value) || $this->value === 'All') {
       return;
     }
 
     $this->ensureMyTable();
-    $operator = empty($this->value) ? 'NOT IN' : 'IN';
+    // A checked box shows only duplicates.
+    $operator = 'IN';
 
     // Placeholders are namespaced by handler id so the filter can appear more
     // than once in a single view without colliding.

--- a/web/modules/custom/campuschampions/src/Plugin/views/filter/DuplicateSubmissionName.php
+++ b/web/modules/custom/campuschampions/src/Plugin/views/filter/DuplicateSubmissionName.php
@@ -87,8 +87,17 @@ class DuplicateSubmissionName extends BooleanOperator {
     $first = ':cc_dup_first_' . $suffix;
     $last = ':cc_dup_last_' . $suffix;
 
+    // Collapse repeated whitespace as well as trimming, so "Bathiya" and
+    // "Bathiya " (or a double space) count as the same applicant.
     $name_expression = "CONCAT(LOWER(TRIM(f.value)), '|', LOWER(TRIM(l.value)))";
     $inner_expression = "CONCAT(LOWER(TRIM(f2.value)), '|', LOWER(TRIM(l2.value)))";
+
+    // A duplicate that matters is the same name approved more than once — the
+    // supersede lifecycle already handles a normal reapply (old approved rows
+    // become superseded). Only count approved submissions on both sides so the
+    // view surfaces the genuine anomaly rather than every historical reapply.
+    $status_join = "INNER JOIN {webform_submission_data} st ON st.sid = s.sid AND st.name = 'status' AND st.value = 'approved'";
+    $inner_status_join = "INNER JOIN {webform_submission_data} st2 ON st2.sid = s2.sid AND st2.name = 'status' AND st2.value = 'approved'";
 
     $sql = <<<SQL
 {$this->tableAlias}.sid $operator (
@@ -96,6 +105,7 @@ class DuplicateSubmissionName extends BooleanOperator {
   FROM {webform_submission} s
   INNER JOIN {webform_submission_data} f ON f.sid = s.sid AND f.name = $first
   INNER JOIN {webform_submission_data} l ON l.sid = s.sid AND l.name = $last
+  $status_join
   WHERE s.webform_id = $wid
     AND $name_expression IN (
       SELECT dupes.cc_dup_name FROM (
@@ -103,6 +113,7 @@ class DuplicateSubmissionName extends BooleanOperator {
         FROM {webform_submission} s2
         INNER JOIN {webform_submission_data} f2 ON f2.sid = s2.sid AND f2.name = $first
         INNER JOIN {webform_submission_data} l2 ON l2.sid = s2.sid AND l2.name = $last
+        $inner_status_join
         WHERE s2.webform_id = $wid
         GROUP BY $inner_expression
         HAVING COUNT(DISTINCT s2.sid) > 1

--- a/web/sites/default/config/default/views.view.cc_applications.yml
+++ b/web/sites/default/config/default/views.view.cc_applications.yml
@@ -10,6 +10,7 @@ dependencies:
     - user.role.lt
     - webform.webform.join_campus_champions
   module:
+    - campuschampions
     - user
     - views_bulk_operations
     - webform
@@ -688,6 +689,47 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        cc_duplicate_name:
+          id: cc_duplicate_name
+          table: webform_submission
+          field: cc_duplicate_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: campuschampions_duplicate_submission_name
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Duplicate names only'
+            description: 'Show only applications whose first and last name match another application.'
+            use_operator: false
+            operator: cc_duplicate_name_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: cc_duplicate_name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          webform_id: join_campus_champions
+          first_name_element: user_first_name
+          last_name_element: user_last_name
       style:
         type: table
         options:
@@ -719,7 +761,7 @@ display:
               empty_column: false
               responsive: ''
             webform_submission_value:
-              sortable: false
+              sortable: true
               default_sort_order: asc
               align: ''
               separator: ''

--- a/web/sites/default/config/default/views.view.cc_applications.yml
+++ b/web/sites/default/config/default/views.view.cc_applications.yml
@@ -98,6 +98,11 @@ display:
               preconfiguration:
                 add_confirmation: false
                 label_override: Approve
+            -
+              action_id: campuschampions_supersede
+              preconfiguration:
+                add_confirmation: true
+                label_override: 'Mark as superseded'
           force_selection_info: false
         webform_submission_value_3:
           id: webform_submission_value_3

--- a/web/sites/default/config/default/views.view.cc_applications.yml
+++ b/web/sites/default/config/default/views.view.cc_applications.yml
@@ -629,6 +629,46 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
+        cc_applicant_search:
+          id: cc_applicant_search
+          table: webform_submission
+          field: cc_applicant_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: campuschampions_applicant_search
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Search
+            description: 'Search by applicant first name, last name, or email.'
+            use_operator: false
+            operator: cc_applicant_search_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          webform_id: join_campus_champions
+          search_elements: 'user_first_name,user_last_name,user_email'
         webform_submission_value:
           id: webform_submission_value
           table: webform_submission_field_join_campus_champions_status

--- a/web/sites/default/config/default/views.view.cc_applications.yml
+++ b/web/sites/default/config/default/views.view.cc_applications.yml
@@ -551,7 +551,7 @@ display:
         options:
           offset: 0
           pagination_heading_level: h4
-          items_per_page: 10
+          items_per_page: 50
           total_pages: null
           id: 0
           tags:

--- a/web/sites/default/config/default/webform.webform.join_campus_champions.yml
+++ b/web/sites/default/config/default/webform.webform.join_campus_champions.yml
@@ -22,6 +22,8 @@ elements: |-
       new: new
       approved: approved
       declined: declined
+      superseded: superseded
+      removed: removed
     '#default_value': new
     '#access_create_roles': {  }
     '#access_update_roles':
@@ -62,20 +64,6 @@ elements: |-
       - anonymous
     '#text': '<h2>Account Details</h2><p>Do you have an ACCESS ID you''d like to use?</p><p><a class="btn btn-primary rounded-pill" href="/login">Login with ACCESS CI</a></p>'
     '#format': full_html
-  carnegie_classification:
-    '#type': textfield
-    '#title': 'Carnegie Classification'
-    '#description': 'Enter your institution name to lookup your Carnegie Code.'
-    '#states':
-      required:
-        - ':input[name="i_can_t_find_my_carnegie_code"]':
-            empty: true
-        - or
-        - ':input[name="i_can_t_find_my_carnegie_code"]':
-            unchecked: true
-  i_can_t_find_my_carnegie_code:
-    '#type': checkbox
-    '#title': "I can't find my Carnegie Code"
   username:
     '#type': textfield
     '#title': Username
@@ -94,6 +82,52 @@ elements: |-
     '#title': Email
     '#description': '<span style="-webkit-text-stroke-width:0px; background-color:#ffffff; color:#6c757d; display:inline !important; float:none; font-family:museo-sans,sans-serif; font-size:12.8px; font-style:normal; font-variant-caps:normal; font-variant-ligatures:normal; font-weight:400; letter-spacing:normal; orphans:2; text-align:left; text-decoration-color:initial; text-decoration-style:initial; text-decoration-thickness:initial; text-indent:0px; text-transform:none; white-space:normal; widows:2; word-spacing:0px">A valid email address. All emails from the system will be sent to this address. The email address is not made public and will only be used if you wish to receive a new password or wish to receive certain news or notifications by email.</span>'
     '#required': true
+  field_access_organization:
+    '#type': entity_autocomplete
+    '#title': 'ACCESS Organization'
+    '#description': 'Select your institution. If it is not listed, choose "Other" and enter it below.'
+    '#target_type': node
+    '#selection_handler': 'default:node'
+    '#selection_settings':
+      target_bundles:
+        access_organization: access_organization
+    '#required': true
+  user_institution:
+    '#type': webform_section
+    '#title': Institution
+    '#title_tag': h5
+    '#states':
+      visible:
+        ':input[name="field_access_organization"]':
+          value: '3695'
+    '#attributes':
+      class:
+        - 'card mb-4'
+    institution_name:
+      '#type': textfield
+      '#title': 'Name of Institution'
+      '#required': true
+    institution_street_address:
+      '#type': webform_address
+      '#title': 'Street Address'
+      '#address__required': true
+      '#address_2__access': false
+      '#city__required': true
+      '#state_province__required': true
+      '#postal_code__required': true
+      '#country__required': true
+      '#required': true
+  carnegie_classification:
+    '#type': textfield
+    '#title': 'Carnegie Classification'
+    '#description': 'Enter your institution name to lookup your Carnegie Code.'
+    '#states':
+      visible:
+        ':input[name="field_access_organization"]':
+          value: '3695'
+      required:
+        ':input[name="field_access_organization"]':
+          value: '3695'
   student_info:
     '#type': webform_section
     '#title': 'Student Champion'
@@ -152,31 +186,6 @@ elements: |-
     supervisor_email:
       '#type': email
       '#title': 'Supervisor Email'
-      '#required': true
-  user_institution:
-    '#type': webform_section
-    '#title': Institution
-    '#title_tag': h5
-    '#states':
-      visible:
-        ':input[name="i_can_t_find_my_carnegie_code"]':
-          checked: true
-    '#attributes':
-      class:
-        - 'card mb-4'
-    institution_name:
-      '#type': textfield
-      '#title': 'Name of Institution'
-      '#required': true
-    institution_street_address:
-      '#type': webform_address
-      '#title': 'Street Address'
-      '#address__required': true
-      '#address_2__access': false
-      '#city__required': true
-      '#state_province__required': true
-      '#postal_code__required': true
-      '#country__required': true
       '#required': true
 css: ''
 javascript: ''

--- a/web/sites/default/config/default/webform.webform.join_campus_champions.yml
+++ b/web/sites/default/config/default/webform.webform.join_campus_champions.yml
@@ -85,7 +85,7 @@ elements: |-
   field_access_organization:
     '#type': entity_autocomplete
     '#title': 'ACCESS Organization'
-    '#description': 'Select your institution. If it is not listed, choose "Other" and enter it below.'
+    '#description': 'Select your institution. If it is not listed, choose "Other" and enter it below. If you are changing institutions, select your new one here and submit a new application with a Letter of Collaboration from that institution. Your organization will update once the application is approved.'
     '#target_type': node
     '#selection_handler': 'default:node'
     '#selection_settings':

--- a/web/sites/default/config/default/webform.webform.join_campus_champions.yml
+++ b/web/sites/default/config/default/webform.webform.join_campus_champions.yml
@@ -85,7 +85,7 @@ elements: |-
   field_access_organization:
     '#type': entity_autocomplete
     '#title': 'ACCESS Organization'
-    '#description': 'Select your institution. If it is not listed, choose "Other" and enter it below. If you are changing institutions, select your new one here and submit a new application with a Letter of Collaboration from that institution. Your organization will update once the application is approved.'
+    '#description': 'Select your institution. If it is not listed, choose "Other" and enter it below.'
     '#target_type': node
     '#selection_handler': 'default:node'
     '#selection_settings':


### PR DESCRIPTION
## Describe context / purpose for this PR
Completes the Campus Champions change-institution process (D8-2789). This reworks and extends the approach in #2068 so that an approved organization change actually moves the champion to their new organization, and captures the organization reliably. It also improves the Campus Champion Applications admin view used to review those applications.

**Supersedes #2068.** This branch was rebuilt from md-2789's feature work (redirect subscriber, read-only org form-alter, duplicate-name filter) plus the completion pieces that #2068 was missing. If this is approved, #2068 should be closed in favor of it.

### Form
- Applicant selects their **ACCESS Organization** directly (entity autocomplete), placed after the email field. This replaces the old carnegie-primary field + "I can't find my Carnegie Code" checkbox.
- Institution and Carnegie fields are revealed only when **"Other"** is chosen. In the Other flow the institution name is a type-ahead against the Carnegie institution list that fills the code on selection and clears it on any edit, so a stale code never sticks to a new institution. Free text is accepted for institutions not in the list (international schools, companies), leaving the code blank, which is correct.
- The organization is prefilled for logged-in users who already have one set, editable in case they are changing it.

### Data
- A `webform_submission` presave stamps the Carnegie code from the selected organization, so the applications export keeps a populated code without a lossy name→org lookup.
- Create and approve read the organization directly from the submission instead of deriving it from the carnegie code.

### Lifecycle
- **Approval** writes the organization to the account, reconciles the submission owner to the resolved account, and supersedes the champion's prior approved submissions.
- **Removal** (the existing remove-champion action) marks the champion's approved submissions as removed.
- Two new submission statuses: `superseded` (replaced by a newer approved application) and `removed` (no longer in the program).
- **Redirect** narrowed to pending-only: an approved champion may file a new application (e.g. to change organizations); only a still-pending submission redirects them to edit it.
- The join form retitles to "Update Your Campus Champions Membership" with an explainer for existing champions.
- **update_10008** backfills historical submissions: reconciles owners, supersedes prior organizations, and marks removed champions. **update_10009** cleans up eleven legacy submissions carrying non-numeric Carnegie codes, re-deriving the code from the submitter's account organization where possible and deleting one known test submission.

### Approval robustness
- The approval action guarded an unguarded `carnegie_classification` data read that could throw an undefined-key warning and abort the whole VBO approval batch when a submission lacked the key.
- The account save, submission owner reconcile, and supersede in the approval action are not atomic, so a mid-sequence failure could leave a record half-approved. Re-running approval converges, but a log alone would go unread, so on failure the admin now sees an on-screen error telling them to re-run.

### Applications admin view
- **Search box** matching a term against the applicant first name, last name, or email, across the separate submission-data rows, so an admin can find an applicant directly. Multi-word queries like "First Last" match across the name fields.
- The **duplicate-names filter** is now a single checkbox rather than a three-option select, since the only useful state is "show duplicates".
- The exposed filters, the Apply button, and the VBO action select and its button are laid out on compact aligned rows. Page size raised so the full duplicate set fits on one page.
- PHPCS violations in `campuschampions.module` cleaned up while touching it, and the two generic `validate_form` / `validate_user_form` handlers renamed to prefixed functions, with new coverage added first so the rename is verified rather than hoped.

### Tests
New Cypress specs cover the applicant search, the duplicate email/username and program-membership validation handlers (previously untested), the pending-submission join redirect, and the supersede/removed status transitions. The organization-field spec and the shared submit flow across several specs were updated to the org-first model. All verified locally on a worktree ddev; the approve-action and applications-admin specs still pass after the changes above.

Note: base is currently `main` — should likely target `md-dev` like the other feature PRs.

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-2789

## Any other related PRs?
- connectci-platform/portal#2068 (the earlier D8-2789 branch this supersedes)

## Link to MultiDev instance
http://md-2789-2-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
