### PR TITLE
md-2794: pin access to events registration contract + fix small-page-size events API pagination

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "require": {
         "access/drupal_seamless_cilogon": "3.0.x-dev",
         "access/infrastructure_news": "1.0.x-dev",
-        "connectci/access": "feat/events-contract-phase1-dev",
+        "connectci/access": "3.0.x-dev",
         "connectci/asp-theme": "main-dev",
         "connectci/campus-champions-theme": "main-dev",
         "connectci/operations_cider": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "require": {
         "access/drupal_seamless_cilogon": "3.0.x-dev",
         "access/infrastructure_news": "1.0.x-dev",
-        "connectci/access": "3.0.x-dev",
+        "connectci/access": "feat/events-contract-phase1-dev",
         "connectci/asp-theme": "main-dev",
         "connectci/campus-champions-theme": "main-dev",
         "connectci/operations_cider": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4489c95e94433b4e0e9110a78bf93ad",
+    "content-hash": "5f725e6f5634e8e1f3f378b0b946e1f4",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -675,17 +675,18 @@
         },
         {
             "name": "connectci/access",
-            "version": "dev-feat/events-contract-phase1",
+            "version": "3.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/access.git",
-                "reference": "11e20f4fd3938c0ec64f8868616cedaba1448566"
+                "reference": "3793d4259869b90a060a02d85133950bd749efea"
             },
             "require": {
                 "firebase/php-jwt": "^6.0 || ^7.0",
                 "gioni06/gpt3-tokenizer": "^1.2",
                 "openai-php/client": "^0.10"
             },
+            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "GPL-2.0+"
@@ -701,7 +702,7 @@
                 "issues": "https://github.com/connectci-platform/access/issues",
                 "source": "https://github.com/connectci-platform/access"
             },
-            "time": "2026-08-04T14:09:12+00:00"
+            "time": "2026-08-04T16:21:54+00:00"
         },
         {
             "name": "connectci/asp-theme",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f725e6f5634e8e1f3f378b0b946e1f4",
+    "content-hash": "c4489c95e94433b4e0e9110a78bf93ad",
     "packages": [
         {
             "name": "access/drupal_seamless_cilogon",
@@ -675,18 +675,17 @@
         },
         {
             "name": "connectci/access",
-            "version": "3.0.x-dev",
+            "version": "dev-feat/events-contract-phase1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/connectci-platform/access.git",
-                "reference": "ff188c7e892881f90448eaf24fa544be18244a88"
+                "reference": "11e20f4fd3938c0ec64f8868616cedaba1448566"
             },
             "require": {
                 "firebase/php-jwt": "^6.0 || ^7.0",
                 "gioni06/gpt3-tokenizer": "^1.2",
                 "openai-php/client": "^0.10"
             },
-            "default-branch": true,
             "type": "drupal-custom-module",
             "license": [
                 "GPL-2.0+"
@@ -702,7 +701,7 @@
                 "issues": "https://github.com/connectci-platform/access/issues",
                 "source": "https://github.com/connectci-platform/access"
             },
-            "time": "2026-08-01T15:30:23+00:00"
+            "time": "2026-08-04T14:09:12+00:00"
         },
         {
             "name": "connectci/asp-theme",

--- a/web/sites/default/config/default/views.view.events_facet.yml
+++ b/web/sites/default/config/default/views.view.events_facet.yml
@@ -7644,7 +7644,7 @@ display:
           expose:
             items_per_page: true
             items_per_page_label: 'Items per page'
-            items_per_page_options: '25, 50, 100, 250, 500'
+            items_per_page_options: '1, 5, 10, 20, 25, 50, 100, 250, 500'
             items_per_page_options_all: true
             items_per_page_options_all_label: '- All -'
             offset: false


### PR DESCRIPTION
## Describe context / purpose for this PR

Two things on this MultiDev branch:

1. Pins `connectci/access` to the `feat/events-contract-phase1` branch so this environment exercises the events registration contract changes against the live site and the ACCESS MCP tools before merge.
2. Fixes a pre-existing events-API pagination bug (config on the events view — see below).

What the pinned access branch does (connectci-platform/access#446):

- `registration_window.opens` no longer tracks wall-clock `now` — open-immediately events return `opens: null` + `registration_open: true`; scheduled events return the configured start. `closes` unchanged.
- `capacity_type` two-state derivation: unlimited (`capacity: null`, `seats_remaining: null`) vs limited (raw capacity + remaining seats). A full limited event stays `limited`, not `unlimited`.
- `eventinstance_id` emitted as a string from the registrations list (fixes int-vs-string chaining on the client).
- Kernel test: a preview registration POST (`confirmed: false`) writes no registrant row.
- OpenAPI documents the new fields and the `{action, status, executed}` write envelope as the MCP-layer transform of the raw Drupal body.

Pagination fix (this repo, `views.view.events_facet`):

- The `/api/2.3/events` data-export display exposed `items_per_page` as a select restricted to `25, 50, 100, 250, 500`. A requested `items_per_page` outside that list failed the exposed-pager select validation and aborted the query, so `?items_per_page=1..20` returned an empty result while 25+ worked. Broaden the allowed options to `1, 5, 10, 20, 25, 50, 100, 250, 500` so small page sizes return data; the larger values remain for existing callers. Pre-existing on `3.0.x` (not caused by the access branch). The matching MCP client change is necyberteam/access-mcp#27.

Verified end-to-end on the MultiDev with the local MCP tools acting as a non-privileged user: get_event (registration_path/capacity_type/opens), register preview→commit→already_registered, cancel preview→commit→not_found, and the not-owner cancel boundary — all correct.

Flow: merge access#446 to `3.0.x`, update the access pin here to `3.0.x-dev`, then merge this PR.

## Issue link

https://cyberteamportal.atlassian.net/browse/D8-2794

## Any other related PRs?

- connectci-platform/access#446 — the access module changes being pinned here.
- necyberteam/access-mcp#27 — the MCP client (events contract + the matching small-page-size change).

## Link to MultiDev instance

http://md-2794-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
