### PR TITLE
config(mcp_bot): drop permissions the acting-user model made redundant

### DIFF
--- a/web/sites/default/config/default/user.role.mcp_bot.yml
+++ b/web/sites/default/config/default/user.role.mcp_bot.yml
@@ -5,18 +5,10 @@ dependencies:
   module:
     - access
     - actions_permissions
-    - content_moderation
-    - node
-    - recurring_events
 id: mcp_bot
 label: mcp-bot
 weight: 31
 is_admin: null
 permissions:
-  - 'administer nodes'
-  - 'create access_news content'
-  - 'delete any access_news content'
-  - 'edit any access_news content'
   - 'execute node_assign_owner_action node'
   - 'use content assist api'
-  - 'view any unpublished content'


### PR DESCRIPTION
## Describe context / purpose for this PR

Now that the acting-user permission model has landed, the `mcp_bot` service role no longer needs its broad content permissions. The MCP write endpoints switch the request to the acting user and authorize against that user's own permissions plus a per-group coordinator check, so `mcp_bot` never exercises god-mode content authority.

Removes from the `mcp_bot` role:

- `administer nodes`
- `delete any access_news content`
- `edit any access_news content`
- `view any unpublished content`
- `create access_news content`

Keeps the two permissions its own request paths still need:

- `use content assist api` — the route `_permission` gate for the content-assist endpoints (suggest_tags / suggest_summary), checked while the request is authenticated as `mcp_bot`.
- `execute node_assign_owner_action node` — assigns a created node's owner.

Drupal recomputes the module dependency list down to `access` + `actions_permissions` to match.

## Verification

Confirmed against the module source and on a local environment pulled from live:

- Announcement create/update/delete and event register/cancel authorize as the switched-in acting user, never against `mcp_bot`'s permissions.
- The `get_my_announcements` draft read relies on `view own unpublished content`, which comes from the acting user's own `authenticated` role — not from `mcp_bot`.
- With the slimmed role applied, the `mcp_bot` account still holds `use content assist api` and `execute node_assign_owner_action node` (a `hasPermission` check), and none of the removed four permissions have any remaining reference in the access module.

## Issue link

https://cyberteamportal.atlassian.net/browse/D8-2794

## Any other related PRs?

Follows the acting-user permission model work (connectci-platform/portal #2080) and the events registration contract (#2082).

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
